### PR TITLE
test(cross): record Homey burst command evidence

### DIFF
--- a/apps/backend/src/plugins/devices-homey/__fixtures__/README.md
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/README.md
@@ -127,5 +127,10 @@ and backend shutdown against live SHS `13.4.1`. Both disable and shutdown remain
 35 seconds, longer than the minimum reconciliation interval. The report contains no endpoint, credential, Homey
 identity, device or zone identifier, inventory data or count, connector count, event payload, response body, or raw
 error.
+The 2026-08-28 burst-command report records three concurrent same-capability Smart Panel requests against live SHS
+`13.4.1`. The production command queue accepted and confirmed the complete target-baseline-target sequence, observed
+the three matching realtime events in order, verified the final authoritative value, restored the baseline, verified
+restoration, and stopped cleanly. The report contains no endpoint, credential, Homey identity, mapping family, device
+or capability identifier, capability value, inventory data, event payload, response body, or raw error.
 
 Before committing regenerated fixtures, inspect every value and key and confirm that no private source value survives.

--- a/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-28-shs-13.4.1-burst-command.json
+++ b/apps/backend/src/plugins/devices-homey/__fixtures__/evidence/2026-08-28-shs-13.4.1-burst-command.json
@@ -1,0 +1,74 @@
+{
+	"metadata": {
+		"probe": "homey-shs-burst-command",
+		"schemaVersion": 1,
+		"sdkVersion": "3.19.2"
+	},
+	"observation": {
+		"baselineRead": true,
+		"concurrentCommandsAccepted": true,
+		"finalReadBackMatched": true,
+		"orderedCapabilityEventsObserved": true,
+		"restorationAccepted": true,
+		"restorationReadBackMatched": true,
+		"restored": true
+	},
+	"session": {
+		"cleanupCompleted": true,
+		"events": [
+			{
+				"event": "service.start.requested",
+				"order": 1
+			},
+			{
+				"event": "service.start.resolved",
+				"order": 2
+			},
+			{
+				"event": "inventory.verified",
+				"order": 3
+			},
+			{
+				"event": "target.bound",
+				"order": 4
+			},
+			{
+				"event": "baseline.read.verified",
+				"order": 5
+			},
+			{
+				"event": "commands.concurrent.requested",
+				"order": 6
+			},
+			{
+				"event": "commands.concurrent.resolved",
+				"order": 7
+			},
+			{
+				"event": "events.ordered.verified",
+				"order": 8
+			},
+			{
+				"event": "final.readback.verified",
+				"order": 9
+			},
+			{
+				"event": "restoration.requested",
+				"order": 10
+			},
+			{
+				"event": "restoration.resolved",
+				"order": 11
+			},
+			{
+				"event": "restoration.readback.verified",
+				"order": 12
+			},
+			{
+				"event": "service.stop.resolved",
+				"order": 13
+			}
+		],
+		"serviceStarted": true
+	}
+}

--- a/apps/backend/test/homey-shs-burst-command.homey-spike.ts
+++ b/apps/backend/test/homey-shs-burst-command.homey-spike.ts
@@ -272,6 +272,29 @@ describe('Homey SHS burst-command probe', () => {
 		).toThrow();
 	});
 
+	it('preserves the sanitized live SHS burst-command evidence', async () => {
+		const evidencePath = join(
+			__dirname,
+			'../src/plugins/devices-homey/__fixtures__/evidence/2026-08-28-shs-13.4.1-burst-command.json',
+		);
+		const evidence = JSON.parse(await readFile(evidencePath, 'utf8')) as unknown;
+
+		assertHomeyShsBurstCommandReportSafe(evidence, config());
+		expect(evidence).toMatchObject({
+			observation: {
+				baselineRead: true,
+				concurrentCommandsAccepted: true,
+				finalReadBackMatched: true,
+				orderedCapabilityEventsObserved: true,
+				restorationAccepted: true,
+				restorationReadBackMatched: true,
+				restored: true,
+			},
+			session: { cleanupCompleted: true, serviceStarted: true },
+		});
+		expect(evidence.session.events).toHaveLength(13);
+	});
+
 	it('writes the report beneath a private non-overwriting directory', async () => {
 		const { report } = await successfulProbe();
 		const parent = await mkdtemp(join(tmpdir(), 'homey-burst-command-'));

--- a/docs/homey-shs-compatibility.md
+++ b/docs/homey-shs-compatibility.md
@@ -558,7 +558,7 @@ variables, clear every unrelated mutation/recovery family, and enter identifiers
 
 ```bash
 for variable in $(env | awk -F= '
-  /^FB_HOMEY_SHS_(CREDENTIAL_ROTATION|LIFECYCLE|MAPPING_CONTROL|ORIGIN_EVENT|REALTIME|RECOVERY|REPLACEMENT|RESTART_EVENT_FLOW|STARTUP|WRITE)_/ {
+  /^FB_HOMEY_SHS_(CREDENTIAL_ROTATION|LIFECYCLE|MAPPING_CONTROL|ORIGIN_EVENT|PLUGIN_LIFECYCLE|REALTIME|RECOVERY|REPLACEMENT|RESTART_EVENT_FLOW|STARTUP|WRITE)_/ {
     print $1
   }
 '); do
@@ -582,6 +582,13 @@ pnpm run homey:probe-burst-command
 The panel value must differ from the current value and use Smart Panel units. The report contains only fixed event
 labels and completion booleans; it excludes the endpoint, credential, Homey identity, mapping target, capability value,
 inventory data, event payload, response body, and raw error. Inspect the controlled equipment after any failed run.
+
+On 2026-08-28, the guarded cover-position run passed against live SHS `13.4.1`. The production service and platform
+path accepted and confirmed all three concurrent target-baseline-target requests, delivered their matching realtime
+capability events in order, and returned the requested final authoritative value. The probe then restored the exact
+baseline, verified restoration with a fresh read, and stopped cleanly. The reviewed report is committed as
+`__fixtures__/evidence/2026-08-28-shs-13.4.1-burst-command.json`; it contains only fixed event labels, ordering numbers,
+public SDK version, and completion booleans.
 
 ## Managed plugin lifecycle and backend shutdown
 
@@ -969,7 +976,7 @@ Fill this matrix using synthetic aliases only.
 | Availability events                        | Absent for synthetic test driver    | Unavailable/restored read-backs passed after full ten-second event windows; physical/Homey-originated evidence remains pending                       |
 | Allowlisted write, event, and read-back    | Pass                                | Requested-value event and read-back passed; restoration of the original value and its second read-back also passed                                   |
 | Smart Panel mapped-family control          | Pass                                | Cover, lighting, and switch passed through production mappings and control; no eligible live lock family was present                                 |
-| Burst updates and concurrent commands      | Pending                             |                                                                                                                                                      |
+| Burst updates and concurrent commands      | Pass                                | Three concurrent mapped cover commands were serialized, confirmed by ordered realtime events and final read-back, then restored exactly              |
 | Plugin disable/enable and backend shutdown | Pass                                | Managed disable, fresh-connector re-enable, and backend shutdown each completed; both 35-second post-stop windows remained fully quiescent           |
 | Network interruption and restoration       | Pass                                | 36 ordered events proved disconnect, nine retries during the 60-second interruption, resubscription, fresh inventory read, and complete cleanup      |
 | SHS restart and reconnect                  | Pass                                | A 23-event write/restart/restore run proved events and read-backs across recovery; the earlier 15-event run independently proved transport recovery  |

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -626,14 +626,15 @@ representative lifecycle failure paths.
 - [x] Separately gated add/rename/zone-move/unavailable/removal lifecycle tests on the allowlisted disposable device only, followed by cleanup.
 - [x] Physical/Homey/flow-originated state changes.
 - [x] Allowlisted Smart Panel control for every writable MVP mapping family available.
-- [ ] Burst updates and concurrent commands.
+- [x] Burst updates and concurrent commands.
 - [x] Plugin disable/enable and backend shutdown with no leaked connections/timers.
 
-A separately gated burst-command probe now prepares the remaining concurrency run. It binds one exact reversible
-writable mapping through the production service and platform path, submits `target → baseline → target` concurrently,
-requires all three matching realtime capability events in order plus an authoritative final read-back, and restores the
-exact baseline before shutdown. Its exact-schema report contains only fixed event labels and completion booleans. The
-matrix item remains open until this guarded probe passes against live SHS and the sanitized report is reviewed.
+The separately gated burst-command probe passed on 2026-08-28 against live SHS `13.4.1`. It bound a reversible cover
+position mapping through the production service and platform path, submitted `target → baseline → target` concurrently,
+accepted and confirmed all three commands, observed their matching realtime capability events in order, and verified
+the final authoritative value. It then restored the exact baseline, verified restoration with a fresh read, and stopped
+cleanly. The reviewed exact-schema report contains only fixed event labels, ordering numbers, public SDK version, and
+completion booleans.
 
 The separately gated, read-only plugin-lifecycle probe passed on 2026-08-28 against live SHS `13.4.1`. The production
 `PluginServiceManagerService` bootstrapped Homey, disabled it through the configuration event path, re-enabled it with a


### PR DESCRIPTION
## Summary

- record the sanitized SHS 13.4.1 concurrent burst-command report
- verify the committed report with the probe's exact-schema privacy assertions
- close the final live lifecycle-matrix item in the compatibility record and implementation plan

## Live evidence

The production Homey service and device platform accepted and confirmed three concurrent same-capability cover commands, observed their matching realtime events in order, and verified the final authoritative value. The probe restored the exact baseline, verified restoration, and stopped cleanly.

The committed report contains only fixed event labels, ordering numbers, public SDK version, and completion booleans.

## Verification

- `pnpm exec jest --config test/jest-homey-spike.json --runInBand test/homey-shs-burst-command.homey-spike.ts`
- `pnpm exec eslint test/homey-shs-burst-command.homey-spike.ts`
- `pnpm run homey:security-gate` (17 suites / 243 tests plus 39 suites / 484 tests)
- `git diff --check`