### PR TITLE
docs(tasks): define Homey Cloud OAuth client boundary

### DIFF
--- a/docs/homey-cloud-oauth.md
+++ b/docs/homey-cloud-oauth.md
@@ -108,7 +108,8 @@ The implementation that follows this record must:
 1. Allow only a signed-in Smart Panel owner or administrator to start authorization.
 2. Generate a cryptographically random, single-use, short-lived `state` bound to the initiating Smart Panel user,
    installation, exact redirect URL, one authorization transaction, and the current active-grant/configuration
-   generation.
+   generation. Capture the initiating user's current authority generation in the transaction as well; this binding
+   identifies the initiator but does not replace a current authorization check.
 3. Return an authorization URL; never proxy or collect the user's Homey credentials.
 4. Keep the callback public at the HTTP-authentication layer because the browser reaches it after Homey authorization,
    then authorize it solely by consuming the exact one-time `state`. Reject missing, expired, replayed, or mismatched
@@ -128,10 +129,12 @@ The implementation that follows this record must:
    transactions.
 8. Authenticate the selected Homey with the candidate grant, then atomically activate its access token, refresh token,
    selected Homey ID, and connector through a serialized compare-and-swap against the active-grant/configuration
-   generation captured when that authorization started. Activation advances the generation. If another flow or
-   configuration mutation won first, reject and clear the stale candidate instead of overwriting it. Until activation
-   succeeds, retain the previous active grant, selected Homey, and connector; never apply a previous Homey ID or another
-   transaction's selection to a candidate account.
+   generation captured when that authorization started. Inside the same serialized activation boundary, re-read the
+   initiating user and require that the user still exists, still has owner or administrator authority, and still
+   matches the captured authority generation. Activation advances the grant/configuration generation. If authority was
+   revoked, the user changed, or another flow or configuration mutation won first, reject and clear the stale candidate
+   instead of overwriting the active grant. Until activation succeeds, retain the previous active grant, selected Homey,
+   and connector; never apply a previous Homey ID or another transaction's selection to a candidate account.
 9. Serialize refresh and token replacement, persist a rotated refresh token atomically, and move to reauthorization
    rather than retrying aggressively after revocation or permanent refresh failure. Reauthorization must not take the
    active connector offline unless the active grant independently becomes invalid or the candidate is activated.

--- a/docs/homey-cloud-oauth.md
+++ b/docs/homey-cloud-oauth.md
@@ -91,8 +91,11 @@ The backend implementation will read these deployment values; values shown here 
 | `FB_HOMEY_CLOUD_REDIRECT_URL`  | No     | Exact absolute registered callback URL; HTTPS outside loopback development; no credentials, fragment, or unexpected query.         |
 
 Access tokens and refresh tokens are per authorization, not deployment client configuration. They must use the generic
-write-only secret boundary or an established encrypted credential store, remain backend-only, and be cleared together
-on disconnect or failed reauthorization. The client secret and tokens must never share a browser-facing DTO.
+write-only secret boundary or an established encrypted credential store and remain backend-only. Disconnect clears the
+active access token, refresh token, and selected Homey together. Reauthorization stages a separate candidate grant and
+must preserve the active grant until the candidate token set is exchanged, persisted, and activated successfully. A
+failed reauthorization clears only its candidate state. The client secret and tokens must never share a browser-facing
+DTO.
 
 ## Authorization boundary for Task 7.2
 
@@ -107,12 +110,14 @@ The implementation that follows this record must:
    state before token exchange.
 5. Redact the code, state, token response, client secret, raw account response, and raw Homey inventory from errors and
    logs.
-6. Exchange the code immediately with a bounded timeout, persist tokens before declaring authorization complete, and
-   clear partial state after any failure.
+6. Exchange the code immediately with a bounded timeout. Stage and persist candidate tokens before atomically activating
+   them; after any exchange, validation, or persistence failure, clear only candidate state and leave an existing active
+   grant and connector untouched.
 7. List sanitized Homey choices after authorization. Auto-select only when exactly one eligible Homey exists; otherwise
    require an explicit stable-ID selection without exposing account details that the admin UI does not need.
 8. Serialize refresh and token replacement, persist a rotated refresh token atomically, and move to reauthorization
-   rather than retrying aggressively after revocation or permanent refresh failure.
+   rather than retrying aggressively after revocation or permanent refresh failure. Reauthorization must not take the
+   active connector offline unless the active grant independently becomes invalid or the candidate is activated.
 9. Disconnect the Homey connector and clear tokens plus the selected Homey before reporting OAuth disconnect success.
 
 The current official client and HTTP references do not document a standards-style token-revocation endpoint. Task 7.2

--- a/docs/homey-cloud-oauth.md
+++ b/docs/homey-cloud-oauth.md
@@ -120,8 +120,10 @@ The implementation that follows this record must:
    initiating-user-bound pending record without activating them. Give the record a short absolute expiry that cannot
    be extended by reads or selection attempts. Never address candidate credentials through a global pending slot.
    Delete its tokens and transaction on expiry, explicit cancellation, terminal failure, or successful activation, and
-   sweep expired abandoned records independently of user traffic. Leave an existing active grant and connector
-   untouched when a candidate is cleared.
+   sweep expired abandoned records independently of user traffic. Cancellation and expiry cleanup must serialize with
+   activation and change or delete the authoritative pending row, so credentials retained by an in-flight request
+   cannot activate after cleanup wins. Leave an existing active grant and connector untouched when a candidate is
+   cleared.
 7. List sanitized Homey choices from that exact candidate transaction. Auto-select only when exactly one eligible Homey
    exists. When none exist, return a sanitized terminal failure and delete the candidate tokens and transaction. When
    multiple exist, require an explicit stable-ID selection bound to the same opaque transaction and initiating user,
@@ -129,12 +131,16 @@ The implementation that follows this record must:
    transactions.
 8. Authenticate the selected Homey with the candidate grant, then atomically activate its access token, refresh token,
    selected Homey ID, and connector through a serialized compare-and-swap against the active-grant/configuration
-   generation captured when that authorization started. Inside the same serialized activation boundary, re-read the
+   generation captured when that authorization started. Use one database transaction and locking boundary shared by
+   activation, candidate cancellation or expiry, and initiating-user demotion or deletion. In that transaction,
+   conditionally consume an existing non-cancelled candidate whose absolute expiry is still in the future; re-read the
    initiating user and require that the user still exists, still has owner or administrator authority, and still
-   matches the captured authority generation. Activation advances the grant/configuration generation. If authority was
-   revoked, the user changed, or another flow or configuration mutation won first, reject and clear the stale candidate
-   instead of overwriting the active grant. Until activation succeeds, retain the previous active grant, selected Homey,
-   and connector; never apply a previous Homey ID or another transaction's selection to a candidate account.
+   matches the captured authority generation. Store the activating user and authority generation on the active grant.
+   Authority mutations under the same boundary must invalidate and disconnect a grant activated by that authority if
+   activation committed first; if the authority mutation, cancellation, expiry, or another configuration mutation won
+   first, the activation's conditional commit must fail and clear any remaining candidate state. Activation advances
+   the grant/configuration generation. Until activation succeeds, retain the previous active grant, selected Homey, and
+   connector; never apply a previous Homey ID or another transaction's selection to a candidate account.
 9. Serialize refresh and token replacement, persist a rotated refresh token atomically, and move to reauthorization
    rather than retrying aggressively after revocation or permanent refresh failure. Reauthorization must not take the
    active connector offline unless the active grant independently becomes invalid or the candidate is activated.

--- a/docs/homey-cloud-oauth.md
+++ b/docs/homey-cloud-oauth.md
@@ -113,7 +113,10 @@ The implementation that follows this record must:
 3. Return an authorization URL; never proxy or collect the user's Homey credentials.
 4. Keep the callback public at the HTTP-authentication layer because the browser reaches it after Homey authorization,
    then authorize it solely by consuming the exact one-time `state`. Reject missing, expired, replayed, or mismatched
-   state before token exchange.
+   state before token exchange. Configure every HTTP server, reverse proxy, and observability layer in front of the
+   callback to omit its query string from access logs or scrub `code`, `state`, and OAuth error parameters before any
+   request-target recording. After consuming the callback, redirect the browser to a clean same-origin result URL with
+   no OAuth query parameters, including on failure.
 5. Redact the code, state, token response, client secret, raw account response, and raw Homey inventory from errors and
    logs.
 6. Exchange the code immediately with a bounded timeout. Stage and persist candidate tokens in a transaction-scoped,
@@ -148,8 +151,9 @@ The implementation that follows this record must:
    grant or restore a disconnected grant. Move to reauthorization rather than retrying aggressively after revocation or
    permanent refresh failure. Reauthorization must not take the active connector offline unless the active grant
    independently becomes invalid or the candidate is activated.
-10. Through that same mutation boundary, invalidate and clear tokens plus the selected Homey, then disconnect the Homey
-    connector before reporting OAuth disconnect success.
+10. Allow only a current Smart Panel owner or administrator to disconnect. Re-read and require that authority inside the
+    same serialized mutation boundary, then invalidate and clear tokens plus the selected Homey and disconnect the
+    Homey connector before reporting OAuth disconnect success.
 
 The current official client and HTTP references do not document a standards-style token-revocation endpoint. Task 7.2
 must verify the current live/API behavior before claiming remote revocation. Until then, disconnect means local token

--- a/docs/homey-cloud-oauth.md
+++ b/docs/homey-cloud-oauth.md
@@ -132,12 +132,16 @@ The implementation that follows this record must:
    multiple exist, require an explicit stable-ID selection bound to the same opaque transaction and initiating user,
    without exposing account details that the admin UI does not need. Reject selection for expired or cleared
    transactions.
-8. Authenticate the selected Homey with the candidate grant, then atomically activate its access token, refresh token,
-   selected Homey ID, and connector through a serialized compare-and-swap against the active-grant/configuration
-   generation captured when that authorization started. Use one database transaction and locking boundary shared by
-   activation, candidate cancellation or expiry, and initiating-user demotion or deletion. In that transaction,
-   conditionally consume an existing non-cancelled candidate whose absolute expiry is still in the future; re-read the
-   initiating user and require that the user still exists, still has owner or administrator authority, and still
+8. Disable SDK automatic token refresh for pending candidate clients. If a candidate access token expires or receives
+   `invalid_token` during inventory listing or selected-Homey authentication, treat it as a terminal failure, delete the
+   exact pending transaction and its credentials through the candidate mutation boundary, and require a new
+   authorization. After authenticating the selected Homey with a still-valid candidate grant, atomically activate its
+   access token, refresh token, selected Homey ID, and connector through a serialized compare-and-swap against the
+   active-grant/configuration generation captured when that authorization started. Use one database transaction and
+   locking boundary shared by activation, candidate cancellation or expiry, and initiating-user demotion or deletion.
+   In that transaction, conditionally consume an existing non-cancelled candidate whose absolute expiry is still in the
+   future; re-read the initiating user and require that the user still exists, still has owner or administrator
+   authority, and still
    matches the captured authority generation. Store the activating user and authority generation on the active grant.
    Authority mutations under the same boundary must invalidate and disconnect a grant activated by that authority if
    activation committed first; if the authority mutation, cancellation, expiry, or another configuration mutation won

--- a/docs/homey-cloud-oauth.md
+++ b/docs/homey-cloud-oauth.md
@@ -95,7 +95,8 @@ write-only secret boundary or an established encrypted credential store and rema
 active access token, refresh token, and selected Homey together. Reauthorization stages a separate candidate grant and
 must preserve the active grant until the candidate token set is exchanged, its Homey is selected and authenticated,
 and the tokens plus selected Homey are activated together successfully. A failed reauthorization clears only its
-candidate state. The client secret and tokens must never share a browser-facing DTO.
+candidate state. Every candidate is isolated by authorization transaction and initiating user; there is no shared
+pending slot. The client secret and tokens must never share a browser-facing DTO.
 
 ## Authorization boundary for Task 7.2
 
@@ -103,21 +104,27 @@ The implementation that follows this record must:
 
 1. Allow only a signed-in Smart Panel owner or administrator to start authorization.
 2. Generate a cryptographically random, single-use, short-lived `state` bound to the initiating Smart Panel user,
-   installation, exact redirect URL, and current Homey configuration generation.
+   installation, exact redirect URL, one authorization transaction, and the current active-grant/configuration
+   generation.
 3. Return an authorization URL; never proxy or collect the user's Homey credentials.
 4. Keep the callback public at the HTTP-authentication layer because the browser reaches it after Homey authorization,
    then authorize it solely by consuming the exact one-time `state`. Reject missing, expired, replayed, or mismatched
    state before token exchange.
 5. Redact the code, state, token response, client secret, raw account response, and raw Homey inventory from errors and
    logs.
-6. Exchange the code immediately with a bounded timeout. Stage and persist candidate tokens in a pending slot without
-   activating them; after any exchange, validation, or persistence failure, clear only candidate state and leave an
+6. Exchange the code immediately with a bounded timeout. Stage and persist candidate tokens in a transaction-scoped,
+   initiating-user-bound pending record without activating them. Never address candidate credentials through a global
+   pending slot. After any exchange, validation, or persistence failure, clear only that transaction and leave an
    existing active grant and connector untouched.
-7. List sanitized Homey choices after authorization. Auto-select only when exactly one eligible Homey exists; otherwise
-   require an explicit stable-ID selection without exposing account details that the admin UI does not need.
+7. List sanitized Homey choices from that exact candidate transaction. Auto-select only when exactly one eligible Homey
+   exists; otherwise require an explicit stable-ID selection bound to the same opaque transaction and initiating user,
+   without exposing account details that the admin UI does not need.
 8. Authenticate the selected Homey with the candidate grant, then atomically activate its access token, refresh token,
-   selected Homey ID, and connector. Until that transaction succeeds, retain the previous active grant, selected Homey,
-   and connector; never apply a previous Homey ID to a new candidate account.
+   selected Homey ID, and connector through a serialized compare-and-swap against the active-grant/configuration
+   generation captured when that authorization started. Activation advances the generation. If another flow or
+   configuration mutation won first, reject and clear the stale candidate instead of overwriting it. Until activation
+   succeeds, retain the previous active grant, selected Homey, and connector; never apply a previous Homey ID or another
+   transaction's selection to a candidate account.
 9. Serialize refresh and token replacement, persist a rotated refresh token atomically, and move to reauthorization
    rather than retrying aggressively after revocation or permanent refresh failure. Reauthorization must not take the
    active connector offline unless the active grant independently becomes invalid or the candidate is activated.

--- a/docs/homey-cloud-oauth.md
+++ b/docs/homey-cloud-oauth.md
@@ -93,9 +93,9 @@ The backend implementation will read these deployment values; values shown here 
 Access tokens and refresh tokens are per authorization, not deployment client configuration. They must use the generic
 write-only secret boundary or an established encrypted credential store and remain backend-only. Disconnect clears the
 active access token, refresh token, and selected Homey together. Reauthorization stages a separate candidate grant and
-must preserve the active grant until the candidate token set is exchanged, persisted, and activated successfully. A
-failed reauthorization clears only its candidate state. The client secret and tokens must never share a browser-facing
-DTO.
+must preserve the active grant until the candidate token set is exchanged, its Homey is selected and authenticated,
+and the tokens plus selected Homey are activated together successfully. A failed reauthorization clears only its
+candidate state. The client secret and tokens must never share a browser-facing DTO.
 
 ## Authorization boundary for Task 7.2
 
@@ -110,15 +110,18 @@ The implementation that follows this record must:
    state before token exchange.
 5. Redact the code, state, token response, client secret, raw account response, and raw Homey inventory from errors and
    logs.
-6. Exchange the code immediately with a bounded timeout. Stage and persist candidate tokens before atomically activating
-   them; after any exchange, validation, or persistence failure, clear only candidate state and leave an existing active
-   grant and connector untouched.
+6. Exchange the code immediately with a bounded timeout. Stage and persist candidate tokens in a pending slot without
+   activating them; after any exchange, validation, or persistence failure, clear only candidate state and leave an
+   existing active grant and connector untouched.
 7. List sanitized Homey choices after authorization. Auto-select only when exactly one eligible Homey exists; otherwise
    require an explicit stable-ID selection without exposing account details that the admin UI does not need.
-8. Serialize refresh and token replacement, persist a rotated refresh token atomically, and move to reauthorization
+8. Authenticate the selected Homey with the candidate grant, then atomically activate its access token, refresh token,
+   selected Homey ID, and connector. Until that transaction succeeds, retain the previous active grant, selected Homey,
+   and connector; never apply a previous Homey ID to a new candidate account.
+9. Serialize refresh and token replacement, persist a rotated refresh token atomically, and move to reauthorization
    rather than retrying aggressively after revocation or permanent refresh failure. Reauthorization must not take the
    active connector offline unless the active grant independently becomes invalid or the candidate is activated.
-9. Disconnect the Homey connector and clear tokens plus the selected Homey before reporting OAuth disconnect success.
+10. Disconnect the Homey connector and clear tokens plus the selected Homey before reporting OAuth disconnect success.
 
 The current official client and HTTP references do not document a standards-style token-revocation endpoint. Task 7.2
 must verify the current live/API behavior before claiming remote revocation. Until then, disconnect means local token

--- a/docs/homey-cloud-oauth.md
+++ b/docs/homey-cloud-oauth.md
@@ -141,10 +141,15 @@ The implementation that follows this record must:
    first, the activation's conditional commit must fail and clear any remaining candidate state. Activation advances
    the grant/configuration generation. Until activation succeeds, retain the previous active grant, selected Homey, and
    connector; never apply a previous Homey ID or another transaction's selection to a candidate account.
-9. Serialize refresh and token replacement, persist a rotated refresh token atomically, and move to reauthorization
-   rather than retrying aggressively after revocation or permanent refresh failure. Reauthorization must not take the
-   active connector offline unless the active grant independently becomes invalid or the candidate is activated.
-10. Disconnect the Homey connector and clear tokens plus the selected Homey before reporting OAuth disconnect success.
+9. Before calling the refresh endpoint, capture the active grant/configuration generation. Persist a successful access
+   and rotated refresh token atomically through the same serialized active-grant mutation boundary used by activation,
+   disconnect, and authority invalidation, conditional on that generation and grant identity still being current.
+   Discard and redact a late refresh response if any competing mutation won first; it must never overwrite a replacement
+   grant or restore a disconnected grant. Move to reauthorization rather than retrying aggressively after revocation or
+   permanent refresh failure. Reauthorization must not take the active connector offline unless the active grant
+   independently becomes invalid or the candidate is activated.
+10. Through that same mutation boundary, invalidate and clear tokens plus the selected Homey, then disconnect the Homey
+    connector before reporting OAuth disconnect success.
 
 The current official client and HTTP references do not document a standards-style token-revocation endpoint. Task 7.2
 must verify the current live/API behavior before claiming remote revocation. Until then, disconnect means local token

--- a/docs/homey-cloud-oauth.md
+++ b/docs/homey-cloud-oauth.md
@@ -96,7 +96,10 @@ active access token, refresh token, and selected Homey together. Reauthorization
 must preserve the active grant until the candidate token set is exchanged, its Homey is selected and authenticated,
 and the tokens plus selected Homey are activated together successfully. A failed reauthorization clears only its
 candidate state. Every candidate is isolated by authorization transaction and initiating user; there is no shared
-pending slot. The client secret and tokens must never share a browser-facing DTO.
+pending slot. Pending candidates have a short, server-enforced expiry independent of the consumed OAuth `state`.
+Expiration, an explicit cancel action, or abandoning the selection flow deletes the candidate tokens and transaction;
+a periodic cleanup also removes expired records that receive no further request. The client secret and tokens must
+never share a browser-facing DTO.
 
 ## Authorization boundary for Task 7.2
 
@@ -113,12 +116,16 @@ The implementation that follows this record must:
 5. Redact the code, state, token response, client secret, raw account response, and raw Homey inventory from errors and
    logs.
 6. Exchange the code immediately with a bounded timeout. Stage and persist candidate tokens in a transaction-scoped,
-   initiating-user-bound pending record without activating them. Never address candidate credentials through a global
-   pending slot. After any exchange, validation, or persistence failure, clear only that transaction and leave an
-   existing active grant and connector untouched.
+   initiating-user-bound pending record without activating them. Give the record a short absolute expiry that cannot
+   be extended by reads or selection attempts. Never address candidate credentials through a global pending slot.
+   Delete its tokens and transaction on expiry, explicit cancellation, terminal failure, or successful activation, and
+   sweep expired abandoned records independently of user traffic. Leave an existing active grant and connector
+   untouched when a candidate is cleared.
 7. List sanitized Homey choices from that exact candidate transaction. Auto-select only when exactly one eligible Homey
-   exists; otherwise require an explicit stable-ID selection bound to the same opaque transaction and initiating user,
-   without exposing account details that the admin UI does not need.
+   exists. When none exist, return a sanitized terminal failure and delete the candidate tokens and transaction. When
+   multiple exist, require an explicit stable-ID selection bound to the same opaque transaction and initiating user,
+   without exposing account details that the admin UI does not need. Reject selection for expired or cleared
+   transactions.
 8. Authenticate the selected Homey with the candidate grant, then atomically activate its access token, refresh token,
    selected Homey ID, and connector through a serialized compare-and-swap against the active-grant/configuration
    generation captured when that authorization started. Activation advances the generation. If another flow or

--- a/docs/homey-cloud-oauth.md
+++ b/docs/homey-cloud-oauth.md
@@ -1,0 +1,139 @@
+# Homey Cloud OAuth Compatibility Record
+
+**Status:** Client registration and Homey Cloud access approval pending; deployment contract recorded
+
+**Evidence date:** 2026-08-28
+
+**Related task:** `FEATURE-PLUGIN-HOMEY`, Milestone 7
+
+## Purpose
+
+This record defines the external client-registration and deployment boundary for the Homey Cloud connector before its
+authorization endpoints are implemented. It deliberately contains no client ID, client secret, authorization code,
+token, account identifier, Homey identifier, callback state, or installation address.
+
+The relevant official references are:
+
+- [Homey Web API overview](https://api.developer.homey.app/)
+- [Homey HTTP and Socket.IO specification](https://api.developer.homey.app/http-and-socket.io/http-specification)
+- [`AthomCloudAPI` reference](https://athombv.github.io/node-homey-api/AthomCloudAPI.html)
+- [Homey Developer Tools](https://tools.developer.homey.app/)
+
+## Verified published contract
+
+| Area                | Published behavior and implementation consequence                                                                                                                                                                         |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Client registration | A Homey Web API client supplies a client ID, client secret, registered redirect URI set, and scopes.                                                                                                                      |
+| Authorization       | The user authorizes at `https://api.athom.com/oauth2/authorise`; Smart Panel must send an exact registered redirect URI and a one-time `state`.                                                                           |
+| Code exchange       | The backend exchanges the short-lived authorization code at `https://api.athom.com/oauth2/token` using HTTP Basic authentication with the client ID and secret.                                                           |
+| Token lifecycle     | The pinned `homey-api` `3.19.2` client models access and refresh tokens and serializes concurrent refresh. Smart Panel must persist every returned token field and safely handle responses that rotate the refresh token. |
+| Account inventory   | The authenticated user response can contain multiple Homeys. Smart Panel must list them and require an explicit selection instead of silently choosing the first.                                                         |
+| Homey session       | The selected Homey is authenticated through the SDK, which returns the platform/API-specific Homey client used by the cloud connector.                                                                                    |
+| Default limit       | A new Web API client is limited to 100 Homey Pro users.                                                                                                                                                                   |
+| Homey Cloud access  | Homey Cloud access is not automatic. The client owner must request a limit increase in Developer Tools and include the request to connect to Homey Cloud.                                                                 |
+| PKCE                | Neither the current Homey HTTP guide nor the pinned SDK's authorization-code API documents PKCE parameters. Smart Panel must not invent them; it must use a confidential backend exchange plus strict `state` handling.   |
+
+The public guide describes an authorization code as valid for 30 seconds. Callback processing must therefore be
+bounded and exchange the code immediately. The guide also describes tokens as valid until revoked, while the pinned SDK
+supports `expires_in`, refresh tokens, and automatic refresh. The implementation must accept both behaviors: use expiry
+metadata when present, refresh before or after an authorization failure through one serialized owner, and require
+reauthorization when refresh is rejected.
+
+## Distribution decision
+
+Smart Panel is self-hosted software with installation-specific origins. It must not embed one reusable FastyBird client
+secret in source code, browser assets, the container image, an installer, or a default configuration. A shared secret in
+a distributed artifact is not confidential, and one fixed callback cannot represent arbitrary private installation
+origins.
+
+The first cloud profile therefore uses a **deployment-owned confidential Web API client**:
+
+1. The deployment owner registers a client in Homey Developer Tools.
+2. The owner registers the exact callback URL for that Smart Panel installation.
+3. The client ID, client secret, and callback URL are provisioned to the backend as deployment configuration.
+4. Smart Panel users see only the normal Homey consent flow; they never enter Homey account credentials into Smart
+   Panel.
+
+A future FastyBird-hosted authorization broker could provide one centrally approved client for arbitrary installations,
+but it would add a new hosted trust boundary, token relay, availability requirement, privacy policy, and incident
+response surface. It is not implied by this milestone and must receive a separate design review before replacing the
+deployment-owned client model.
+
+## Client registration template
+
+Register only exact callback URLs. Do not register wildcards, derive a callback from request `Host`/forwarded headers,
+or accept a callback override from an authorization request.
+
+| Field                | Required value                                                                                                                          |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| Client name          | `FastyBird Smart Panel` plus a deployment qualifier when Developer Tools requires unique names                                          |
+| Development callback | `http://localhost:3000/api/v1/plugins/devices-homey/oauth/callback` only for a backend and browser running on the same development host |
+| Installed callback   | `https://<exact-smart-panel-origin>/api/v1/plugins/devices-homey/oauth/callback`                                                        |
+| Client type          | Confidential backend client                                                                                                             |
+| Intended scopes      | `homey.system.readonly`, `homey.zone.readonly`, `homey.device.readonly`, `homey.device.control`                                         |
+
+The scope names above are the minimum manager scopes used by the existing connector contract. Their availability and
+consent presentation must be confirmed in the current Developer Tools registration form before the live client item is
+checked. Do not add flow, app, user-administration, pairing, driver, insight, or device-management scopes.
+
+For an installation without an exact browser-reachable HTTPS origin, cloud mode remains unavailable. Loopback HTTP is
+development-only and works only when the browser follows the callback to the same machine as the backend. A LAN address,
+`.local` name, reverse-proxy hostname, or port is not interchangeable with a registered value.
+
+## Deployment configuration contract
+
+The backend implementation will read these deployment values; values shown here are names and placeholders only:
+
+| Variable                       | Secret | Validation and exposure                                                                                                            |
+| ------------------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `FB_HOMEY_CLOUD_CLIENT_ID`     | No     | Required for cloud mode; trimmed non-empty value; never returned unless a later UI has a concrete need for a configured indicator. |
+| `FB_HOMEY_CLOUD_CLIENT_SECRET` | Yes    | Required for cloud mode; backend-only; never returned, logged, placed in OpenAPI examples, or sent to the admin/panel clients.     |
+| `FB_HOMEY_CLOUD_REDIRECT_URL`  | No     | Exact absolute registered callback URL; HTTPS outside loopback development; no credentials, fragment, or unexpected query.         |
+
+Access tokens and refresh tokens are per authorization, not deployment client configuration. They must use the generic
+write-only secret boundary or an established encrypted credential store, remain backend-only, and be cleared together
+on disconnect or failed reauthorization. The client secret and tokens must never share a browser-facing DTO.
+
+## Authorization boundary for Task 7.2
+
+The implementation that follows this record must:
+
+1. Allow only a signed-in Smart Panel owner or administrator to start authorization.
+2. Generate a cryptographically random, single-use, short-lived `state` bound to the initiating Smart Panel user,
+   installation, exact redirect URL, and current Homey configuration generation.
+3. Return an authorization URL; never proxy or collect the user's Homey credentials.
+4. Keep the callback public at the HTTP-authentication layer because the browser reaches it after Homey authorization,
+   then authorize it solely by consuming the exact one-time `state`. Reject missing, expired, replayed, or mismatched
+   state before token exchange.
+5. Redact the code, state, token response, client secret, raw account response, and raw Homey inventory from errors and
+   logs.
+6. Exchange the code immediately with a bounded timeout, persist tokens before declaring authorization complete, and
+   clear partial state after any failure.
+7. List sanitized Homey choices after authorization. Auto-select only when exactly one eligible Homey exists; otherwise
+   require an explicit stable-ID selection without exposing account details that the admin UI does not need.
+8. Serialize refresh and token replacement, persist a rotated refresh token atomically, and move to reauthorization
+   rather than retrying aggressively after revocation or permanent refresh failure.
+9. Disconnect the Homey connector and clear tokens plus the selected Homey before reporting OAuth disconnect success.
+
+The current official client and HTTP references do not document a standards-style token-revocation endpoint. Task 7.2
+must verify the current live/API behavior before claiming remote revocation. Until then, disconnect means local token
+deletion and connector teardown, while the operator can revoke the grant from Homey account controls.
+
+## External registration and approval checklist
+
+- [ ] Create a dedicated development Web API client in Homey Developer Tools.
+- [ ] Register the exact development callback and confirm whether loopback HTTP is accepted.
+- [ ] Confirm that Developer Tools exposes the four intended minimum scopes with the expected consent text.
+- [ ] Complete one authorization-code exchange without recording any returned identifier or secret in the repository.
+- [ ] Verify multi-Homey listing shape with a sanitized synthetic contract or account that contains multiple eligible
+      Homeys.
+- [ ] Request the user-limit increase and explicit Homey Cloud access required for production use.
+- [ ] Record Athom's approval outcome, effective limit, required branding/legal material, and any rate-limit conditions
+      without including correspondence that contains private account data.
+- [ ] Register the exact production callback only after the production public origin is final.
+
+## Gate for implementation
+
+Task 7.2 may build the authorization state machine and tests behind a disabled cloud mode using fakes. Live cloud mode
+must remain unavailable until the dedicated client exists, the exact callback and scopes are verified, and Athom has
+approved Homey Cloud access. No code may reuse a Homey CLI/mobile client identity or another product's client secret.

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -820,7 +820,19 @@ This milestone starts only after the local MVP is stable. It should be a separat
 
 - [ ] Register the OAuth client and production/development redirect URIs.
 - [ ] Confirm current user limits, approval requirements, scopes, and branding/legal requirements with Athom.
-- [ ] Record client configuration as deployment secrets, not repository values.
+- [x] Record client configuration as deployment secrets, not repository values.
+
+The 2026-08-28 published-contract audit is recorded in `docs/homey-cloud-oauth.md`. Homey's current Web API guide limits
+a new client to 100 Homey Pro users and requires a limit-increase request for a higher limit and optional Homey Cloud
+access. The pinned SDK requires a confidential client secret for authorization-code exchange and refresh, supports a
+registered redirect URL and OAuth `state`, and does not document PKCE. Because Smart Panel is distributed self-hosted
+software with installation-specific origins, no shared client secret may be embedded in repository or release
+artifacts. The first cloud profile uses deployment-owned client credentials and an exact deployment callback; a hosted
+FastyBird authorization broker would require a separate design and trust boundary.
+
+The registration and external-approval items remain unchecked until a dedicated client is created in Homey Developer
+Tools, the four minimum system/zone/device-read/device-control scopes and exact callbacks are accepted, and Athom's
+Homey Cloud access, user limit, branding/legal, and rate-limit conditions are recorded without private account data.
 
 ### Task 7.2: Implement cloud authorization
 

--- a/tasks/features/FEATURE-PLUGIN-HOMEY.md
+++ b/tasks/features/FEATURE-PLUGIN-HOMEY.md
@@ -5,7 +5,7 @@ Type: feature
 Scope: backend, admin, panel
 Size: large
 Parent: (none)
-Status: review
+Status: in-progress
 Created: 2026-08-12
 
 ## 1. Business goal
@@ -165,6 +165,19 @@ I want to connect Homey, adopt its devices, receive live state updates, and cont
 - [ ] The cloud connector passes the same connector contract suite as the local connector.
 - [ ] Mapping, adoption, state sync, and control services contain no cloud-specific forks outside connector/authorization boundaries.
 - [ ] User limits, approval requirements, redirect URIs, and deployment steps are documented.
+
+### Cloud client registration audit
+
+Starting the separately scoped Phase 2 work returns the overall epic to `in-progress`; the local MVP remains
+review-ready under its release audit below.
+
+The 2026-08-28 published-contract audit in `docs/homey-cloud-oauth.md` records the deployment-owned confidential-client
+model, exact callback shape, intended minimum scopes, secret names, OAuth state boundary, multi-Homey selection gate,
+and the external registration/approval checklist. Homey's current guide limits new clients to 100 Homey Pro users and
+requires a limit-increase request to raise that limit and optionally connect to Homey Cloud. Live cloud mode therefore
+remains unavailable until a dedicated client is registered, the callbacks and scopes are accepted, and Athom's Homey
+Cloud approval plus current branding/legal and rate-limit conditions are recorded. No shared client identity or secret
+will be embedded in Smart Panel artifacts.
 
 ### Local MVP release audit
 


### PR DESCRIPTION
## Summary

- record the published Homey Web API OAuth and client-registration contract
- select deployment-owned confidential clients so no shared secret ships in Smart Panel artifacts
- define callback, scope, state, token, multi-Homey selection, and external approval gates
- return the epic to in-progress for the separately scoped cloud milestone

## Verification

- `apps/website/node_modules/.bin/prettier --check docs/homey-cloud-oauth.md docs/superpowers/plans/2026-08-12-homey-integration.md tasks/features/FEATURE-PLUGIN-HOMEY.md`
- `git diff --check`

## External gate

Live cloud mode remains disabled until a dedicated Athom client is registered, its exact callbacks and minimum scopes are accepted, and Homey Cloud access is approved.