### PR TITLE
feat(cross): add Homey cloud OAuth state foundation

### DIFF
--- a/apps/backend/src/plugins/devices-homey/connectors/homey-local-connector.factory.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-local-connector.factory.spec.ts
@@ -1,11 +1,12 @@
 import { HomeyLocalConnectorFactory } from './homey-local-connector.factory';
 import { HomeyLocalConnector } from './homey-local.connector';
-import { HomeySdkClientFactoryService } from './homey-sdk.client';
+import { HomeySdkClientFactory } from './homey-sdk.client';
 
 describe('HomeyLocalConnectorFactory', () => {
 	it('creates a distinct connector core for each saved configuration generation', () => {
-		const sdkFactory = { createLocalApi: jest.fn() };
-		const factory = new HomeyLocalConnectorFactory(sdkFactory as unknown as HomeySdkClientFactoryService);
+		const createLocalApi = jest.fn();
+		const sdkFactory: HomeySdkClientFactory = { createLocalApi };
+		const factory = new HomeyLocalConnectorFactory(sdkFactory);
 		const config = {
 			url: 'http://homey.invalid:4859',
 			apiKey: 'sentinel-api-key',
@@ -18,6 +19,6 @@ describe('HomeyLocalConnectorFactory', () => {
 		expect(first).toBeInstanceOf(HomeyLocalConnector);
 		expect(second).toBeInstanceOf(HomeyLocalConnector);
 		expect(second).not.toBe(first);
-		expect(sdkFactory.createLocalApi).not.toHaveBeenCalled();
+		expect(createLocalApi).not.toHaveBeenCalled();
 	});
 });

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-local-connector.factory.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-local-connector.factory.ts
@@ -1,14 +1,17 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 
 import { HomeyConnectorFactory, HomeyConnectorFactoryConfig } from './homey-connector.factory';
 import { HomeyConnector } from './homey-connector.interface';
 import { HomeyLocalConnector } from './homey-local.connector';
-import { HomeySdkClientFactoryService } from './homey-sdk.client';
+import { HomeySdkClientFactory, HomeySdkClientFactoryService } from './homey-sdk.client';
 import { HomeySdkTransport } from './homey-sdk.transport';
 
 @Injectable()
 export class HomeyLocalConnectorFactory implements HomeyConnectorFactory {
-	constructor(private readonly sdkFactory: HomeySdkClientFactoryService) {}
+	constructor(
+		@Inject(HomeySdkClientFactoryService)
+		private readonly sdkFactory: HomeySdkClientFactory,
+	) {}
 
 	create(config: HomeyConnectorFactoryConfig): HomeyConnector {
 		return new HomeyLocalConnector(new HomeySdkTransport(config, this.sdkFactory));

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.spec.ts
@@ -1,0 +1,28 @@
+import { HOMEY_CLOUD_CALLBACK_PATH, HOMEY_CLOUD_SCOPES } from '../devices-homey.constants';
+
+import { HomeySdkClientFactoryService } from './homey-sdk.client';
+
+describe('HomeySdkClientFactoryService', () => {
+	it('creates a Homey Cloud authorization URL without exposing the client secret', () => {
+		const factory = new HomeySdkClientFactoryService();
+		const clientSecret = 'deployment-client-secret';
+		const redirectUrl = `https://panel.example.com${HOMEY_CLOUD_CALLBACK_PATH}`;
+		const state = 'single-use-random-state';
+		const result = factory.createCloudAuthorizationUrl({
+			clientId: 'deployment-client-id',
+			clientSecret,
+			redirectUrl,
+			scopes: [...HOMEY_CLOUD_SCOPES],
+			state,
+		});
+		const url = new URL(result);
+
+		expect(url.origin + url.pathname).toBe('https://api.athom.com/oauth2/authorise');
+		expect(url.searchParams.get('response_type')).toBe('code');
+		expect(url.searchParams.get('client_id')).toBe('deployment-client-id');
+		expect(url.searchParams.get('redirect_uri')).toBe(redirectUrl);
+		expect(url.searchParams.get('scope')).toBe(HOMEY_CLOUD_SCOPES.join(','));
+		expect(url.searchParams.get('state')).toBe(state);
+		expect(result).not.toContain(clientSecret);
+	});
+});

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.spec.ts
@@ -1,8 +1,19 @@
 import { HOMEY_CLOUD_CALLBACK_PATH, HOMEY_CLOUD_SCOPES } from '../devices-homey.constants';
+import { HomeyCloudConfigurationError } from '../errors/homey-cloud-authorization.error';
 
 import { HomeySdkClientFactoryService } from './homey-sdk.client';
 
 describe('HomeySdkClientFactoryService', () => {
+	const originalBaseUrl = process.env.ATHOM_CLOUD_API_BASEURL;
+
+	afterEach(() => {
+		if (originalBaseUrl === undefined) {
+			delete process.env.ATHOM_CLOUD_API_BASEURL;
+		} else {
+			process.env.ATHOM_CLOUD_API_BASEURL = originalBaseUrl;
+		}
+	});
+
 	it('creates a Homey Cloud authorization URL without exposing the client secret', () => {
 		const factory = new HomeySdkClientFactoryService();
 		const clientSecret = 'deployment-client-secret';
@@ -24,5 +35,20 @@ describe('HomeySdkClientFactoryService', () => {
 		expect(url.searchParams.get('scope')).toBe(HOMEY_CLOUD_SCOPES.join(','));
 		expect(url.searchParams.get('state')).toBe(state);
 		expect(result).not.toContain(clientSecret);
+	});
+
+	it('rejects an authorization URL redirected by the SDK base URL environment override', () => {
+		process.env.ATHOM_CLOUD_API_BASEURL = 'https://untrusted.example.com';
+		const factory = new HomeySdkClientFactoryService();
+
+		expect(() =>
+			factory.createCloudAuthorizationUrl({
+				clientId: 'deployment-client-id',
+				clientSecret: 'deployment-client-secret',
+				redirectUrl: `https://panel.example.com${HOMEY_CLOUD_CALLBACK_PATH}`,
+				scopes: [...HOMEY_CLOUD_SCOPES],
+				state: 'single-use-random-state',
+			}),
+		).toThrow(HomeyCloudConfigurationError);
 	});
 });

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.ts
@@ -1,4 +1,4 @@
-import { HomeyAPI } from 'homey-api';
+import { AthomCloudAPI, HomeyAPI } from 'homey-api';
 
 import { Injectable } from '@nestjs/common';
 
@@ -61,13 +61,40 @@ export interface HomeySdkClientFactory {
 	createLocalApi(options: { address: string; token: string }): Promise<HomeySdkClient>;
 }
 
+export interface HomeyCloudSdkClientFactory {
+	createCloudAuthorizationUrl(options: {
+		clientId: string;
+		clientSecret: string;
+		redirectUrl: string;
+		scopes: string[];
+		state: string;
+	}): string;
+}
+
 @Injectable()
-export class HomeySdkClientFactoryService implements HomeySdkClientFactory {
+export class HomeySdkClientFactoryService implements HomeySdkClientFactory, HomeyCloudSdkClientFactory {
 	async createLocalApi(options: { address: string; token: string }): Promise<HomeySdkClient> {
 		return (await HomeyAPI.createLocalAPI({
 			address: options.address,
 			token: options.token,
 			debug: null,
 		})) as HomeySdkClient;
+	}
+
+	createCloudAuthorizationUrl(options: {
+		clientId: string;
+		clientSecret: string;
+		redirectUrl: string;
+		scopes: string[];
+		state: string;
+	}): string {
+		const cloudApi = new AthomCloudAPI({
+			clientId: options.clientId,
+			clientSecret: options.clientSecret,
+			redirectUrl: options.redirectUrl,
+			autoRefreshTokens: false,
+		});
+
+		return cloudApi.getLoginUrl({ state: options.state, scopes: options.scopes });
 	}
 }

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.ts
@@ -2,6 +2,9 @@ import { AthomCloudAPI, HomeyAPI } from 'homey-api';
 
 import { Injectable } from '@nestjs/common';
 
+import { HOMEY_CLOUD_AUTHORIZE_URL } from '../devices-homey.constants';
+import { HomeyCloudConfigurationError } from '../errors/homey-cloud-authorization.error';
+
 export type HomeySdkEventListener = (...arguments_: unknown[]) => Promise<void> | void;
 
 export interface HomeySdkEventSource {
@@ -94,7 +97,24 @@ export class HomeySdkClientFactoryService implements HomeySdkClientFactory, Home
 			redirectUrl: options.redirectUrl,
 			autoRefreshTokens: false,
 		});
+		const authorizeUrl = cloudApi.getLoginUrl({ state: options.state, scopes: options.scopes });
 
-		return cloudApi.getLoginUrl({ state: options.state, scopes: options.scopes });
+		this.assertCloudAuthorizationEndpoint(authorizeUrl);
+
+		return authorizeUrl;
+	}
+
+	private assertCloudAuthorizationEndpoint(value: string): void {
+		let url: URL;
+
+		try {
+			url = new URL(value);
+		} catch {
+			throw new HomeyCloudConfigurationError('Homey Cloud authorization endpoint is invalid');
+		}
+
+		if (url.username || url.password || url.origin + url.pathname !== HOMEY_CLOUD_AUTHORIZE_URL) {
+			throw new HomeyCloudConfigurationError('Homey Cloud authorization endpoint is invalid');
+		}
 	}
 }

--- a/apps/backend/src/plugins/devices-homey/devices-homey.constants.ts
+++ b/apps/backend/src/plugins/devices-homey/devices-homey.constants.ts
@@ -39,6 +39,27 @@ export const HOMEY_RECONNECT_MAX_DELAY_MS = 30000;
 
 export const HOMEY_RECONNECT_JITTER_RATIO = 0.2;
 
+export const HOMEY_CLOUD_AUTHORIZE_URL = 'https://api.athom.com/oauth2/authorise';
+
+export const HOMEY_CLOUD_CALLBACK_PATH = '/api/v1/plugins/devices-homey/oauth/callback';
+
+export const HOMEY_CLOUD_CLIENT_ID_ENV = 'FB_HOMEY_CLOUD_CLIENT_ID';
+
+export const HOMEY_CLOUD_CLIENT_SECRET_ENV = 'FB_HOMEY_CLOUD_CLIENT_SECRET';
+
+export const HOMEY_CLOUD_REDIRECT_URL_ENV = 'FB_HOMEY_CLOUD_REDIRECT_URL';
+
+export const HOMEY_CLOUD_SCOPES = [
+	'homey.system.readonly',
+	'homey.zone.readonly',
+	'homey.device.readonly',
+	'homey.device.control',
+] as const;
+
+export const HOMEY_CLOUD_AUTHORIZATION_STATE_TTL_MS = 5 * 60 * 1000;
+
+export const HOMEY_CLOUD_MAX_PENDING_AUTHORIZATIONS = 32;
+
 export enum HomeyConnectionState {
 	STOPPED = 'stopped',
 	CONNECTING = 'connecting',

--- a/apps/backend/src/plugins/devices-homey/devices-homey.plugin.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/devices-homey.plugin.spec.ts
@@ -24,6 +24,8 @@ import { HomeyPropertyMappingStorageService } from './mappings/property-mapping-
 import { HomeyConfigModel } from './models/config.model';
 import { HomeyDevicePlatform } from './platforms/homey-device.platform';
 import { HomeyAdoptionLockService } from './services/homey-adoption-lock.service';
+import { HomeyCloudAuthorizationStateService } from './services/homey-cloud-authorization-state.service';
+import { HomeyCloudClientConfigService } from './services/homey-cloud-client-config.service';
 import { HomeyConnectionTestService } from './services/homey-connection-test.service';
 import { HomeyDeviceAdoptionService } from './services/homey-device-adoption.service';
 import { HomeyDeviceInventoryService } from './services/homey-device-inventory.service';
@@ -97,6 +99,8 @@ describe('DevicesHomeyPlugin', () => {
 		expect(providers).toEqual(
 			expect.arrayContaining([
 				HomeySdkClientFactoryService,
+				HomeyCloudClientConfigService,
+				HomeyCloudAuthorizationStateService,
 				HomeyLocalConnectorFactory,
 				HomeyConnectionTestService,
 				HomeyMappingLoaderService,

--- a/apps/backend/src/plugins/devices-homey/devices-homey.plugin.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/devices-homey.plugin.spec.ts
@@ -1,3 +1,5 @@
+import { ConfigModule as NestConfigModule } from '@nestjs/config';
+
 import { PluginsTypeMapperService } from '../../modules/config/services/plugins-type-mapper.service';
 import { ChannelsTypeMapperService } from '../../modules/devices/services/channels-type-mapper.service';
 import { ChannelsPropertiesTypeMapperService } from '../../modules/devices/services/channels.properties-type-mapper.service';
@@ -93,6 +95,7 @@ describe('DevicesHomeyPlugin', () => {
 	});
 
 	it('provides a production SDK-backed connector factory through the transport-neutral token', () => {
+		const imports = Reflect.getMetadata('imports', DevicesHomeyPlugin) as unknown[];
 		const providers = Reflect.getMetadata('providers', DevicesHomeyPlugin) as unknown[];
 		const controllers = Reflect.getMetadata('controllers', DevicesHomeyPlugin) as unknown[];
 
@@ -118,6 +121,7 @@ describe('DevicesHomeyPlugin', () => {
 			provide: HOMEY_CONNECTOR_FACTORY,
 			useExisting: HomeyLocalConnectorFactory,
 		});
+		expect(imports).toContain(NestConfigModule);
 		expect(controllers).toContain(HomeyTestConnectionController);
 		expect(controllers).toContain(HomeyDevicesController);
 		expect(controllers).toContain(HomeyMappingPreviewController);

--- a/apps/backend/src/plugins/devices-homey/devices-homey.plugin.ts
+++ b/apps/backend/src/plugins/devices-homey/devices-homey.plugin.ts
@@ -1,4 +1,5 @@
 import { Module, OnModuleInit } from '@nestjs/common';
+import { ConfigModule as NestConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { ConfigModule } from '../../modules/config/config.module';
@@ -78,6 +79,7 @@ import { HomeyService } from './services/homey.service';
 		]),
 		DevicesModule,
 		ConfigModule,
+		NestConfigModule,
 		ExtensionsModule,
 		SwaggerModule,
 	],

--- a/apps/backend/src/plugins/devices-homey/devices-homey.plugin.ts
+++ b/apps/backend/src/plugins/devices-homey/devices-homey.plugin.ts
@@ -53,6 +53,8 @@ import { HomeyPropertyMappingStorageService } from './mappings/property-mapping-
 import { HomeyConfigModel } from './models/config.model';
 import { HomeyDevicePlatform } from './platforms/homey-device.platform';
 import { HomeyAdoptionLockService } from './services/homey-adoption-lock.service';
+import { HomeyCloudAuthorizationStateService } from './services/homey-cloud-authorization-state.service';
+import { HomeyCloudClientConfigService } from './services/homey-cloud-client-config.service';
 import { HomeyConfigValidatorService } from './services/homey-config-validator.service';
 import { HomeyConnectionTestService } from './services/homey-connection-test.service';
 import { HomeyDeviceAdoptionService } from './services/homey-device-adoption.service';
@@ -81,6 +83,8 @@ import { HomeyService } from './services/homey.service';
 	],
 	providers: [
 		HomeyConfigValidatorService,
+		HomeyCloudClientConfigService,
+		HomeyCloudAuthorizationStateService,
 		HomeySdkClientFactoryService,
 		HomeyLocalConnectorFactory,
 		{

--- a/apps/backend/src/plugins/devices-homey/errors/homey-cloud-authorization.error.ts
+++ b/apps/backend/src/plugins/devices-homey/errors/homey-cloud-authorization.error.ts
@@ -1,0 +1,20 @@
+export class HomeyCloudConfigurationError extends Error {
+	constructor(message = 'Homey Cloud client configuration is unavailable') {
+		super(message);
+		this.name = 'HomeyCloudConfigurationError';
+	}
+}
+
+export class HomeyCloudAuthorizationStateError extends Error {
+	constructor(message = 'Homey Cloud authorization state is invalid or expired') {
+		super(message);
+		this.name = 'HomeyCloudAuthorizationStateError';
+	}
+}
+
+export class HomeyCloudAuthorizationCapacityError extends Error {
+	constructor() {
+		super('Homey Cloud authorization is temporarily unavailable');
+		this.name = 'HomeyCloudAuthorizationCapacityError';
+	}
+}

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization-state.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization-state.service.spec.ts
@@ -1,0 +1,124 @@
+import { HomeyCloudSdkClientFactory, HomeySdkClientFactoryService } from '../connectors/homey-sdk.client';
+import {
+	HOMEY_CLOUD_AUTHORIZATION_STATE_TTL_MS,
+	HOMEY_CLOUD_CALLBACK_PATH,
+	HOMEY_CLOUD_MAX_PENDING_AUTHORIZATIONS,
+	HOMEY_CLOUD_SCOPES,
+} from '../devices-homey.constants';
+import {
+	HomeyCloudAuthorizationCapacityError,
+	HomeyCloudAuthorizationStateError,
+} from '../errors/homey-cloud-authorization.error';
+
+import { HomeyCloudAuthorizationStateService } from './homey-cloud-authorization-state.service';
+import { HomeyCloudClientConfigService } from './homey-cloud-client-config.service';
+
+describe('HomeyCloudAuthorizationStateService', () => {
+	const redirectUrl = `https://panel.example.com${HOMEY_CLOUD_CALLBACK_PATH}`;
+	const configuration = {
+		clientId: 'client-id',
+		clientSecret: 'client-secret',
+		redirectUrl,
+	};
+	const start = {
+		activeGrantGeneration: 7,
+		authorityGeneration: 3,
+		initiatingUserId: 'user-id',
+	};
+
+	let service: HomeyCloudAuthorizationStateService;
+
+	beforeEach(() => {
+		jest.useFakeTimers();
+		jest.setSystemTime(new Date('2026-08-28T12:00:00.000Z'));
+		const sdkClientFactory: HomeyCloudSdkClientFactory = {
+			createCloudAuthorizationUrl: jest.fn((options) => {
+				const url = new URL('https://api.athom.com/oauth2/authorise');
+
+				url.searchParams.set('response_type', 'code');
+				url.searchParams.set('client_id', options.clientId);
+				url.searchParams.set('redirect_uri', options.redirectUrl);
+				url.searchParams.set('state', options.state);
+				url.searchParams.set('scope', options.scopes.join(','));
+
+				return url.toString();
+			}),
+		};
+
+		service = new HomeyCloudAuthorizationStateService(
+			{
+				getConfiguration: jest.fn(() => configuration),
+			} as unknown as HomeyCloudClientConfigService,
+			sdkClientFactory as HomeySdkClientFactoryService,
+		);
+	});
+
+	afterEach(() => {
+		service.onModuleDestroy();
+		jest.useRealTimers();
+	});
+
+	it('creates an exact Homey authorization URL and consumes its state once', () => {
+		const flow = service.create(start);
+		const authorizeUrl = new URL(flow.authorizeUrl);
+		const state = authorizeUrl.searchParams.get('state');
+
+		expect(authorizeUrl.origin + authorizeUrl.pathname).toBe('https://api.athom.com/oauth2/authorise');
+		expect(authorizeUrl.searchParams.get('response_type')).toBe('code');
+		expect(authorizeUrl.searchParams.get('client_id')).toBe(configuration.clientId);
+		expect(authorizeUrl.searchParams.get('redirect_uri')).toBe(redirectUrl);
+		expect(authorizeUrl.searchParams.get('scope')).toBe(HOMEY_CLOUD_SCOPES.join(','));
+		expect(flow.authorizeUrl).not.toContain(configuration.clientSecret);
+		expect(state).toMatch(/^[A-Za-z0-9_-]{43}$/);
+		expect(flow.transactionId).toMatch(/^[A-Za-z0-9_-]{22}$/);
+		expect(flow.expiresAt.getTime()).toBe(Date.now() + HOMEY_CLOUD_AUTHORIZATION_STATE_TTL_MS);
+
+		expect(service.consume(state)).toEqual({
+			...start,
+			expiresAt: flow.expiresAt,
+			redirectUrl,
+			transactionId: flow.transactionId,
+		});
+		expect(() => service.consume(state)).toThrow(HomeyCloudAuthorizationStateError);
+	});
+
+	it('creates independent state and transaction identities for concurrent administrators', () => {
+		const first = service.create(start);
+		const second = service.create({ ...start, initiatingUserId: 'other-admin' });
+
+		expect(new URL(first.authorizeUrl).searchParams.get('state')).not.toBe(
+			new URL(second.authorizeUrl).searchParams.get('state'),
+		);
+		expect(first.transactionId).not.toBe(second.transactionId);
+	});
+
+	it('expires state independently of another request', () => {
+		const state = new URL(service.create(start).authorizeUrl).searchParams.get('state');
+
+		jest.advanceTimersByTime(HOMEY_CLOUD_AUTHORIZATION_STATE_TTL_MS);
+
+		expect(() => service.consume(state)).toThrow(HomeyCloudAuthorizationStateError);
+	});
+
+	it.each([
+		{ ...start, initiatingUserId: '' },
+		{ ...start, authorityGeneration: -1 },
+		{ ...start, activeGrantGeneration: Number.NaN },
+	])('rejects an invalid authorization context', (context) => {
+		expect(() => service.create(context)).toThrow(TypeError);
+	});
+
+	it('uses a generic error for missing, malformed, and unknown state', () => {
+		for (const state of ['', 'not-a-real-state', 'another-unknown-state']) {
+			expect(() => service.consume(state)).toThrow('Homey Cloud authorization state is invalid or expired');
+		}
+	});
+
+	it('bounds pending authorization state', () => {
+		for (let index = 0; index < HOMEY_CLOUD_MAX_PENDING_AUTHORIZATIONS; index += 1) {
+			service.create({ ...start, initiatingUserId: `user-${index}` });
+		}
+
+		expect(() => service.create(start)).toThrow(HomeyCloudAuthorizationCapacityError);
+	});
+});

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization-state.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization-state.service.spec.ts
@@ -8,6 +8,7 @@ import {
 import {
 	HomeyCloudAuthorizationCapacityError,
 	HomeyCloudAuthorizationStateError,
+	HomeyCloudConfigurationError,
 } from '../errors/homey-cloud-authorization.error';
 
 import { HomeyCloudAuthorizationStateService } from './homey-cloud-authorization-state.service';
@@ -120,5 +121,26 @@ describe('HomeyCloudAuthorizationStateService', () => {
 		}
 
 		expect(() => service.create(start)).toThrow(HomeyCloudAuthorizationCapacityError);
+	});
+
+	it('does not reserve state capacity when authorization URL creation fails', () => {
+		const failingService = new HomeyCloudAuthorizationStateService(
+			{
+				getConfiguration: jest.fn(() => configuration),
+			} as unknown as HomeyCloudClientConfigService,
+			{
+				createCloudAuthorizationUrl: jest.fn(() => {
+					throw new HomeyCloudConfigurationError('Homey Cloud authorization endpoint is invalid');
+				}),
+			} as unknown as HomeySdkClientFactoryService,
+		);
+
+		try {
+			for (let index = 0; index <= HOMEY_CLOUD_MAX_PENDING_AUTHORIZATIONS; index += 1) {
+				expect(() => failingService.create(start)).toThrow(HomeyCloudConfigurationError);
+			}
+		} finally {
+			failingService.onModuleDestroy();
+		}
 	});
 });

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization-state.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization-state.service.ts
@@ -1,0 +1,153 @@
+import { createHash, randomBytes } from 'crypto';
+
+import { Injectable, OnModuleDestroy } from '@nestjs/common';
+
+import { HomeySdkClientFactoryService } from '../connectors/homey-sdk.client';
+import {
+	HOMEY_CLOUD_AUTHORIZATION_STATE_TTL_MS,
+	HOMEY_CLOUD_MAX_PENDING_AUTHORIZATIONS,
+	HOMEY_CLOUD_SCOPES,
+} from '../devices-homey.constants';
+import {
+	HomeyCloudAuthorizationCapacityError,
+	HomeyCloudAuthorizationStateError,
+} from '../errors/homey-cloud-authorization.error';
+
+import { HomeyCloudClientConfigService } from './homey-cloud-client-config.service';
+
+interface PendingAuthorizationState {
+	readonly activeGrantGeneration: number;
+	readonly authorityGeneration: number;
+	readonly expiresAt: number;
+	readonly initiatingUserId: string;
+	readonly redirectUrl: string;
+	readonly timer: NodeJS.Timeout;
+	readonly transactionId: string;
+}
+
+export interface HomeyCloudAuthorizationStart {
+	readonly activeGrantGeneration: number;
+	readonly authorityGeneration: number;
+	readonly initiatingUserId: string;
+}
+
+export interface HomeyCloudAuthorizationFlow {
+	readonly authorizeUrl: string;
+	readonly expiresAt: Date;
+	readonly transactionId: string;
+}
+
+export interface HomeyCloudConsumedAuthorization {
+	readonly activeGrantGeneration: number;
+	readonly authorityGeneration: number;
+	readonly expiresAt: Date;
+	readonly initiatingUserId: string;
+	readonly redirectUrl: string;
+	readonly transactionId: string;
+}
+
+@Injectable()
+export class HomeyCloudAuthorizationStateService implements OnModuleDestroy {
+	private readonly pending = new Map<string, PendingAuthorizationState>();
+
+	constructor(
+		private readonly clientConfig: HomeyCloudClientConfigService,
+		private readonly sdkClientFactory: HomeySdkClientFactoryService,
+	) {}
+
+	create(start: HomeyCloudAuthorizationStart): HomeyCloudAuthorizationFlow {
+		this.assertStart(start);
+
+		if (this.pending.size >= HOMEY_CLOUD_MAX_PENDING_AUTHORIZATIONS) {
+			throw new HomeyCloudAuthorizationCapacityError();
+		}
+
+		const configuration = this.clientConfig.getConfiguration();
+		const state = randomBytes(32).toString('base64url');
+		const stateHash = this.hashState(state);
+		const transactionId = randomBytes(16).toString('base64url');
+		const expiresAt = Date.now() + HOMEY_CLOUD_AUTHORIZATION_STATE_TTL_MS;
+		const timer = setTimeout(() => this.expire(stateHash), HOMEY_CLOUD_AUTHORIZATION_STATE_TTL_MS);
+
+		timer.unref();
+
+		this.pending.set(stateHash, {
+			activeGrantGeneration: start.activeGrantGeneration,
+			authorityGeneration: start.authorityGeneration,
+			expiresAt,
+			initiatingUserId: start.initiatingUserId,
+			redirectUrl: configuration.redirectUrl,
+			timer,
+			transactionId,
+		});
+
+		const authorizeUrl = this.sdkClientFactory.createCloudAuthorizationUrl({
+			clientId: configuration.clientId,
+			clientSecret: configuration.clientSecret,
+			redirectUrl: configuration.redirectUrl,
+			scopes: [...HOMEY_CLOUD_SCOPES],
+			state,
+		});
+
+		return {
+			authorizeUrl,
+			expiresAt: new Date(expiresAt),
+			transactionId,
+		};
+	}
+
+	consume(state: string): HomeyCloudConsumedAuthorization {
+		if (typeof state !== 'string' || state.length === 0) throw new HomeyCloudAuthorizationStateError();
+
+		const stateHash = this.hashState(state);
+		const pending = this.pending.get(stateHash);
+
+		if (!pending) throw new HomeyCloudAuthorizationStateError();
+
+		this.pending.delete(stateHash);
+		clearTimeout(pending.timer);
+
+		if (pending.expiresAt <= Date.now()) throw new HomeyCloudAuthorizationStateError();
+
+		return {
+			activeGrantGeneration: pending.activeGrantGeneration,
+			authorityGeneration: pending.authorityGeneration,
+			expiresAt: new Date(pending.expiresAt),
+			initiatingUserId: pending.initiatingUserId,
+			redirectUrl: pending.redirectUrl,
+			transactionId: pending.transactionId,
+		};
+	}
+
+	onModuleDestroy(): void {
+		for (const pending of this.pending.values()) clearTimeout(pending.timer);
+
+		this.pending.clear();
+	}
+
+	private assertStart(start: HomeyCloudAuthorizationStart): void {
+		if (
+			typeof start.initiatingUserId !== 'string' ||
+			start.initiatingUserId.trim().length === 0 ||
+			!Number.isSafeInteger(start.authorityGeneration) ||
+			start.authorityGeneration < 0 ||
+			!Number.isSafeInteger(start.activeGrantGeneration) ||
+			start.activeGrantGeneration < 0
+		) {
+			throw new TypeError('Homey Cloud authorization start context is invalid');
+		}
+	}
+
+	private expire(stateHash: string): void {
+		const pending = this.pending.get(stateHash);
+
+		if (!pending) return;
+
+		this.pending.delete(stateHash);
+		clearTimeout(pending.timer);
+	}
+
+	private hashState(state: string): string {
+		return createHash('sha256').update(state).digest('base64url');
+	}
+}

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization-state.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization-state.service.ts
@@ -67,6 +67,13 @@ export class HomeyCloudAuthorizationStateService implements OnModuleDestroy {
 		const stateHash = this.hashState(state);
 		const transactionId = randomBytes(16).toString('base64url');
 		const expiresAt = Date.now() + HOMEY_CLOUD_AUTHORIZATION_STATE_TTL_MS;
+		const authorizeUrl = this.sdkClientFactory.createCloudAuthorizationUrl({
+			clientId: configuration.clientId,
+			clientSecret: configuration.clientSecret,
+			redirectUrl: configuration.redirectUrl,
+			scopes: [...HOMEY_CLOUD_SCOPES],
+			state,
+		});
 		const timer = setTimeout(() => this.expire(stateHash), HOMEY_CLOUD_AUTHORIZATION_STATE_TTL_MS);
 
 		timer.unref();
@@ -79,14 +86,6 @@ export class HomeyCloudAuthorizationStateService implements OnModuleDestroy {
 			redirectUrl: configuration.redirectUrl,
 			timer,
 			transactionId,
-		});
-
-		const authorizeUrl = this.sdkClientFactory.createCloudAuthorizationUrl({
-			clientId: configuration.clientId,
-			clientSecret: configuration.clientSecret,
-			redirectUrl: configuration.redirectUrl,
-			scopes: [...HOMEY_CLOUD_SCOPES],
-			state,
 		});
 
 		return {

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-client-config.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-client-config.service.spec.ts
@@ -1,0 +1,66 @@
+import { ConfigService as NestConfigService } from '@nestjs/config';
+
+import {
+	HOMEY_CLOUD_CALLBACK_PATH,
+	HOMEY_CLOUD_CLIENT_ID_ENV,
+	HOMEY_CLOUD_CLIENT_SECRET_ENV,
+	HOMEY_CLOUD_REDIRECT_URL_ENV,
+} from '../devices-homey.constants';
+import { HomeyCloudConfigurationError } from '../errors/homey-cloud-authorization.error';
+
+import { HomeyCloudClientConfigService } from './homey-cloud-client-config.service';
+
+describe('HomeyCloudClientConfigService', () => {
+	const valid = {
+		[HOMEY_CLOUD_CLIENT_ID_ENV]: ' client-id ',
+		[HOMEY_CLOUD_CLIENT_SECRET_ENV]: ' client-secret ',
+		[HOMEY_CLOUD_REDIRECT_URL_ENV]: `https://panel.example.com${HOMEY_CLOUD_CALLBACK_PATH}`,
+	};
+
+	function create(values: Record<string, unknown> = valid): HomeyCloudClientConfigService {
+		return new HomeyCloudClientConfigService({
+			get: jest.fn((key: string) => values[key]),
+		} as unknown as NestConfigService);
+	}
+
+	it('returns trimmed deployment-owned client configuration', () => {
+		expect(create().getConfiguration()).toEqual({
+			clientId: 'client-id',
+			clientSecret: 'client-secret',
+			redirectUrl: `https://panel.example.com${HOMEY_CLOUD_CALLBACK_PATH}`,
+		});
+		expect(create().isConfigured()).toBe(true);
+	});
+
+	it.each([HOMEY_CLOUD_CLIENT_ID_ENV, HOMEY_CLOUD_CLIENT_SECRET_ENV, HOMEY_CLOUD_REDIRECT_URL_ENV])(
+		'fails closed when %s is missing',
+		(key) => {
+			const service = create({ ...valid, [key]: '   ' });
+
+			expect(() => service.getConfiguration()).toThrow(HomeyCloudConfigurationError);
+			expect(service.isConfigured()).toBe(false);
+		},
+	);
+
+	it.each([
+		'not-a-url',
+		`http://panel.example.com${HOMEY_CLOUD_CALLBACK_PATH}`,
+		'https://user:password@panel.example.com/api/v1/plugins/devices-homey/oauth/callback',
+		'https://panel.example.com/api/v1/plugins/devices-homey/oauth/callback?next=/admin',
+		'https://panel.example.com/api/v1/plugins/devices-homey/oauth/callback#fragment',
+		'https://panel.example.com/api/v1/plugins/devices-homey/oauth/other',
+	])('rejects an unsafe or inexact redirect URL: %s', (redirectUrl) => {
+		const service = create({ ...valid, [HOMEY_CLOUD_REDIRECT_URL_ENV]: redirectUrl });
+
+		expect(() => service.getConfiguration()).toThrow(HomeyCloudConfigurationError);
+		expect(service.isConfigured()).toBe(false);
+	});
+
+	it.each(['localhost', '127.0.0.1', '[::1]'])('allows HTTP only for the loopback host %s', (host) => {
+		const redirectUrl = `http://${host}:3000${HOMEY_CLOUD_CALLBACK_PATH}`;
+
+		expect(create({ ...valid, [HOMEY_CLOUD_REDIRECT_URL_ENV]: redirectUrl }).getConfiguration().redirectUrl).toBe(
+			redirectUrl,
+		);
+	});
+});

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-client-config.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-client-config.service.ts
@@ -1,0 +1,79 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService as NestConfigService } from '@nestjs/config';
+
+import {
+	HOMEY_CLOUD_CALLBACK_PATH,
+	HOMEY_CLOUD_CLIENT_ID_ENV,
+	HOMEY_CLOUD_CLIENT_SECRET_ENV,
+	HOMEY_CLOUD_REDIRECT_URL_ENV,
+} from '../devices-homey.constants';
+import { HomeyCloudConfigurationError } from '../errors/homey-cloud-authorization.error';
+
+export interface HomeyCloudClientConfiguration {
+	readonly clientId: string;
+	readonly clientSecret: string;
+	readonly redirectUrl: string;
+}
+
+@Injectable()
+export class HomeyCloudClientConfigService {
+	constructor(private readonly config: NestConfigService) {}
+
+	isConfigured(): boolean {
+		try {
+			this.getConfiguration();
+
+			return true;
+		} catch (error) {
+			if (error instanceof HomeyCloudConfigurationError) return false;
+
+			throw error;
+		}
+	}
+
+	getConfiguration(): HomeyCloudClientConfiguration {
+		const clientId = this.readRequired(HOMEY_CLOUD_CLIENT_ID_ENV);
+		const clientSecret = this.readRequired(HOMEY_CLOUD_CLIENT_SECRET_ENV);
+		const redirectUrl = this.readRequired(HOMEY_CLOUD_REDIRECT_URL_ENV);
+
+		this.assertRedirectUrl(redirectUrl);
+
+		return { clientId, clientSecret, redirectUrl };
+	}
+
+	private readRequired(key: string): string {
+		const value = this.config.get<unknown>(key);
+
+		if (typeof value !== 'string' || value.trim().length === 0) {
+			throw new HomeyCloudConfigurationError(`Homey Cloud configuration is missing ${key}`);
+		}
+
+		return value.trim();
+	}
+
+	private assertRedirectUrl(value: string): void {
+		let url: URL;
+
+		try {
+			url = new URL(value);
+		} catch {
+			throw new HomeyCloudConfigurationError(`${HOMEY_CLOUD_REDIRECT_URL_ENV} must be an absolute URL`);
+		}
+
+		const loopbackHosts = new Set(['localhost', '127.0.0.1', '[::1]', '::1']);
+		const isLoopbackHttp = url.protocol === 'http:' && loopbackHosts.has(url.hostname.toLowerCase());
+		const isHttps = url.protocol === 'https:';
+
+		if (!isHttps && !isLoopbackHttp) {
+			throw new HomeyCloudConfigurationError(
+				`${HOMEY_CLOUD_REDIRECT_URL_ENV} must use HTTPS outside loopback development`,
+			);
+		}
+
+		if (url.username || url.password || url.search || url.hash || url.pathname !== HOMEY_CLOUD_CALLBACK_PATH) {
+			throw new HomeyCloudConfigurationError(
+				`${HOMEY_CLOUD_REDIRECT_URL_ENV} must be the exact credential-free Homey Cloud callback URL`,
+			);
+		}
+	}
+}

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -842,6 +842,22 @@ Homey Cloud access, user limit, branding/legal, and rate-limit conditions are re
 - [ ] List/select a Homey when an account has more than one.
 - [ ] Add security-focused controller/service tests.
 
+Task 7.2 is delivered behind disabled cloud mode in reviewable slices:
+
+- [x] **7.2a — Deployment and state foundation:** validate the deployment-owned client ID, secret, and exact callback;
+      generate the SDK authorization URL with candidate auto-refresh disabled; keep only a hash of bounded, single-use
+      state; bind it to the initiating user plus authority/active-grant generations; and expire it independently of
+      follow-up traffic. No cloud route is exposed by this slice.
+- [ ] **7.2b — Grant persistence and mutation gate:** add incremental storage for pending/active grant metadata and
+      write-only token material, then serialize activation, cancellation, expiry, refresh, disconnect, configuration,
+      and user-authority invalidation.
+- [ ] **7.2c — Provider exchange and Homey selection:** exchange the code with a bounded timeout, stage candidate tokens,
+      sanitize eligible Homey choices, support exact transaction-bound selection, authenticate the selected Homey, and
+      activate only through the mutation gate.
+- [ ] **7.2d — HTTP authorization surface:** add privileged start/select/cancel/disconnect/reconnect routes plus the
+      state-authorized public callback, clean callback redirect, ingress query-redaction requirements, and the complete
+      security/race test matrix.
+
 ### Task 7.3: Implement `HomeyCloudConnector`
 
 - [ ] Implement the same connector contract and normalized error categories.


### PR DESCRIPTION
## Summary

- Validate deployment-owned Homey Cloud client credentials and the exact callback URL.
- Add bounded, hashed, single-use authorization state bound to the initiating user and authorization generations.
- Route Homey SDK authorization URL creation through the reviewed SDK adapter with candidate auto-refresh disabled.
- Record Task 7.2a progress while keeping all cloud routes unavailable.

## Verification

- `pnpm --filter ./apps/backend exec jest --runInBand src/plugins/devices-homey` — 40 suites and 476 tests passed during PR creation.
- Focused OAuth and SDK boundary suite — 5 suites and 28 tests passed.
- Targeted ESLint passed.
- `pnpm --filter ./apps/backend run build` passed.
- Prettier and `git diff --check` passed.