### PR TITLE
feat(backend): persist Homey Cloud authorization grants

### DIFF
--- a/apps/backend/src/migrations/1000000000025-AddHomeyCloudGrants.ts
+++ b/apps/backend/src/migrations/1000000000025-AddHomeyCloudGrants.ts
@@ -1,0 +1,87 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+const AUTHORIZATION_STATE_KEY = 'primary';
+
+export class AddHomeyCloudGrants1000000000025 implements MigrationInterface {
+	name = 'AddHomeyCloudGrants1000000000025';
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			`CREATE TABLE "devices_homey_cloud_authorization_state" (` +
+				`"key" varchar PRIMARY KEY NOT NULL, ` +
+				`"activeGrantGeneration" integer NOT NULL DEFAULT (0), ` +
+				`"configurationGeneration" integer NOT NULL DEFAULT (0))`,
+		);
+		await queryRunner.query(
+			`INSERT INTO "devices_homey_cloud_authorization_state" ` +
+				`("key", "activeGrantGeneration", "configurationGeneration") VALUES (?, 0, 0)`,
+			[AUTHORIZATION_STATE_KEY],
+		);
+
+		await queryRunner.query(
+			`CREATE TABLE "devices_homey_cloud_user_authorities" (` +
+				`"userId" varchar PRIMARY KEY NOT NULL, "generation" integer NOT NULL DEFAULT (0))`,
+		);
+
+		await queryRunner.query(
+			`CREATE TABLE "devices_homey_cloud_pending_grants" (` +
+				`"transactionId" varchar PRIMARY KEY NOT NULL, ` +
+				`"initiatingUserId" varchar NOT NULL, ` +
+				`"authorityGeneration" integer NOT NULL, ` +
+				`"activeGrantGeneration" integer NOT NULL, ` +
+				`"configurationGeneration" integer NOT NULL, ` +
+				`"redirectUrl" text NOT NULL, ` +
+				`"tokenType" varchar NOT NULL, ` +
+				`"accessToken" text NOT NULL, ` +
+				`"refreshToken" text, ` +
+				`"expiresIn" integer, ` +
+				`"grantType" varchar, ` +
+				`"tokenIssuedAt" integer NOT NULL, ` +
+				`"expiresAt" integer NOT NULL, ` +
+				`"createdAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP))`,
+		);
+		await queryRunner.query(
+			`CREATE INDEX "IDX_homey_cloud_pending_user" ` + `ON "devices_homey_cloud_pending_grants" ("initiatingUserId")`,
+		);
+		await queryRunner.query(
+			`CREATE INDEX "IDX_homey_cloud_pending_expiry" ` + `ON "devices_homey_cloud_pending_grants" ("expiresAt")`,
+		);
+
+		await queryRunner.query(
+			`CREATE TABLE "devices_homey_cloud_active_grants" (` +
+				`"key" varchar PRIMARY KEY NOT NULL, ` +
+				`"grantIdentifier" varchar NOT NULL, ` +
+				`"activatedById" varchar NOT NULL, ` +
+				`"authorityGeneration" integer NOT NULL, ` +
+				`"generation" integer NOT NULL, ` +
+				`"configurationGeneration" integer NOT NULL, ` +
+				`"selectedHomeyId" varchar NOT NULL, ` +
+				`"tokenType" varchar NOT NULL, ` +
+				`"accessToken" text NOT NULL, ` +
+				`"refreshToken" text, ` +
+				`"expiresIn" integer, ` +
+				`"grantType" varchar, ` +
+				`"tokenIssuedAt" integer NOT NULL, ` +
+				`"activatedAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP), ` +
+				`"updatedAt" datetime)`,
+		);
+		await queryRunner.query(
+			`CREATE UNIQUE INDEX "IDX_homey_cloud_active_identifier" ` +
+				`ON "devices_homey_cloud_active_grants" ("grantIdentifier")`,
+		);
+		await queryRunner.query(
+			`CREATE INDEX "IDX_homey_cloud_active_user" ` + `ON "devices_homey_cloud_active_grants" ("activatedById")`,
+		);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(`DROP INDEX "IDX_homey_cloud_active_user"`);
+		await queryRunner.query(`DROP INDEX "IDX_homey_cloud_active_identifier"`);
+		await queryRunner.query(`DROP TABLE "devices_homey_cloud_active_grants"`);
+		await queryRunner.query(`DROP INDEX "IDX_homey_cloud_pending_expiry"`);
+		await queryRunner.query(`DROP INDEX "IDX_homey_cloud_pending_user"`);
+		await queryRunner.query(`DROP TABLE "devices_homey_cloud_pending_grants"`);
+		await queryRunner.query(`DROP TABLE "devices_homey_cloud_user_authorities"`);
+		await queryRunner.query(`DROP TABLE "devices_homey_cloud_authorization_state"`);
+	}
+}

--- a/apps/backend/src/migrations/1000000000025-AddHomeyCloudGrants.ts
+++ b/apps/backend/src/migrations/1000000000025-AddHomeyCloudGrants.ts
@@ -10,11 +10,13 @@ export class AddHomeyCloudGrants1000000000025 implements MigrationInterface {
 			`CREATE TABLE "devices_homey_cloud_authorization_state" (` +
 				`"key" varchar PRIMARY KEY NOT NULL, ` +
 				`"activeGrantGeneration" integer NOT NULL DEFAULT (0), ` +
-				`"configurationGeneration" integer NOT NULL DEFAULT (0))`,
+				`"configurationGeneration" integer NOT NULL DEFAULT (0), ` +
+				`"configurationFingerprint" varchar)`,
 		);
 		await queryRunner.query(
 			`INSERT INTO "devices_homey_cloud_authorization_state" ` +
-				`("key", "activeGrantGeneration", "configurationGeneration") VALUES (?, 0, 0)`,
+				`("key", "activeGrantGeneration", "configurationGeneration", "configurationFingerprint") ` +
+				`VALUES (?, 0, 0, NULL)`,
 			[AUTHORIZATION_STATE_KEY],
 		);
 

--- a/apps/backend/src/migrations/__tests__/1000000000025-AddHomeyCloudGrants.spec.ts
+++ b/apps/backend/src/migrations/__tests__/1000000000025-AddHomeyCloudGrants.spec.ts
@@ -22,7 +22,12 @@ describe('AddHomeyCloudGrants1000000000025', () => {
 		await migration.up(queryRunner);
 
 		await expect(queryRunner.query(`SELECT * FROM "devices_homey_cloud_authorization_state"`)).resolves.toEqual([
-			{ key: 'primary', activeGrantGeneration: 0, configurationGeneration: 0 },
+			{
+				key: 'primary',
+				activeGrantGeneration: 0,
+				configurationGeneration: 0,
+				configurationFingerprint: null,
+			},
 		]);
 		await expect(tableColumns('devices_homey_cloud_user_authorities')).resolves.toEqual(['userId', 'generation']);
 		await expect(tableColumns('devices_homey_cloud_pending_grants')).resolves.toEqual([

--- a/apps/backend/src/migrations/__tests__/1000000000025-AddHomeyCloudGrants.spec.ts
+++ b/apps/backend/src/migrations/__tests__/1000000000025-AddHomeyCloudGrants.spec.ts
@@ -1,0 +1,103 @@
+import { DataSource, QueryRunner } from 'typeorm';
+
+import { AddHomeyCloudGrants1000000000025 } from '../1000000000025-AddHomeyCloudGrants';
+
+describe('AddHomeyCloudGrants1000000000025', () => {
+	let dataSource: DataSource;
+	let queryRunner: QueryRunner;
+	const migration = new AddHomeyCloudGrants1000000000025();
+
+	beforeEach(async () => {
+		dataSource = new DataSource({ type: 'sqlite', database: ':memory:', entities: [], synchronize: false });
+		await dataSource.initialize();
+		queryRunner = dataSource.createQueryRunner();
+	});
+
+	afterEach(async () => {
+		await queryRunner.release();
+		await dataSource.destroy();
+	});
+
+	it('creates generation, authority, isolated candidate, and active grant storage', async () => {
+		await migration.up(queryRunner);
+
+		await expect(queryRunner.query(`SELECT * FROM "devices_homey_cloud_authorization_state"`)).resolves.toEqual([
+			{ key: 'primary', activeGrantGeneration: 0, configurationGeneration: 0 },
+		]);
+		await expect(tableColumns('devices_homey_cloud_user_authorities')).resolves.toEqual(['userId', 'generation']);
+		await expect(tableColumns('devices_homey_cloud_pending_grants')).resolves.toEqual([
+			'transactionId',
+			'initiatingUserId',
+			'authorityGeneration',
+			'activeGrantGeneration',
+			'configurationGeneration',
+			'redirectUrl',
+			'tokenType',
+			'accessToken',
+			'refreshToken',
+			'expiresIn',
+			'grantType',
+			'tokenIssuedAt',
+			'expiresAt',
+			'createdAt',
+		]);
+		await expect(tableColumns('devices_homey_cloud_active_grants')).resolves.toEqual([
+			'key',
+			'grantIdentifier',
+			'activatedById',
+			'authorityGeneration',
+			'generation',
+			'configurationGeneration',
+			'selectedHomeyId',
+			'tokenType',
+			'accessToken',
+			'refreshToken',
+			'expiresIn',
+			'grantType',
+			'tokenIssuedAt',
+			'activatedAt',
+			'updatedAt',
+		]);
+		await expect(indexNames('devices_homey_cloud_pending_grants')).resolves.toEqual([
+			'IDX_homey_cloud_pending_expiry',
+			'IDX_homey_cloud_pending_user',
+			'sqlite_autoindex_devices_homey_cloud_pending_grants_1',
+		]);
+		await expect(indexNames('devices_homey_cloud_active_grants')).resolves.toEqual([
+			'IDX_homey_cloud_active_identifier',
+			'IDX_homey_cloud_active_user',
+			'sqlite_autoindex_devices_homey_cloud_active_grants_1',
+		]);
+	});
+
+	it('removes every Homey Cloud grant table on rollback', async () => {
+		await migration.up(queryRunner);
+		await migration.down(queryRunner);
+
+		await expect(
+			queryRunner.query(
+				`SELECT "name" FROM sqlite_master WHERE "type" = 'table' AND "name" LIKE 'devices_homey_cloud_%'`,
+			),
+		).resolves.toEqual([]);
+	});
+
+	async function tableColumns(table: string): Promise<string[]> {
+		const columns = (await queryRunner.query(
+			`SELECT "name" FROM pragma_table_info('${table}') ORDER BY "cid"`,
+		)) as Array<{
+			name: string;
+		}>;
+
+		return columns.map(({ name }) => name);
+	}
+
+	async function indexNames(table: string): Promise<string[]> {
+		const indexes = (await queryRunner.query(
+			`SELECT "name" FROM pragma_index_list('${table}') ORDER BY "name"`,
+		)) as Array<{
+			name: string;
+		}>;
+
+		return indexes.map(({ name }) => name);
+	}
+});

--- a/apps/backend/src/modules/users/services/user-lifecycle-mutation-registry.service.spec.ts
+++ b/apps/backend/src/modules/users/services/user-lifecycle-mutation-registry.service.spec.ts
@@ -1,15 +1,22 @@
+import { DataSource, EntityManager } from 'typeorm';
+
 import { UserEntity } from '../entities/users.entity';
 
 import {
 	UserLifecycleMutationHandler,
+	UserLifecycleMutationParticipant,
 	UserLifecycleMutationRegistryService,
 } from './user-lifecycle-mutation-registry.service';
 
 describe('UserLifecycleMutationRegistryService', () => {
 	let service: UserLifecycleMutationRegistryService;
+	let transactionManager: EntityManager;
 
 	beforeEach(() => {
-		service = new UserLifecycleMutationRegistryService();
+		transactionManager = {} as EntityManager;
+		service = new UserLifecycleMutationRegistryService({
+			transaction: <T>(operation: (manager: EntityManager) => Promise<T>): Promise<T> => operation(transactionManager),
+		} as unknown as DataSource);
 	});
 
 	it('commits directly when no lifecycle handler is registered', async () => {
@@ -38,5 +45,50 @@ describe('UserLifecycleMutationRegistryService', () => {
 		service.register(handler);
 
 		expect(() => service.register(handler)).toThrow('already registered');
+	});
+
+	it('runs additive participants and the user commit in one transaction', async () => {
+		const previous = new UserEntity();
+		const next = new UserEntity();
+		const participant = {
+			prepareUpdate: jest.fn().mockResolvedValue(undefined),
+			prepareRemove: jest.fn().mockResolvedValue(undefined),
+		} as UserLifecycleMutationParticipant;
+		const commit = jest.fn().mockResolvedValue('committed');
+		service.registerParticipant(participant);
+
+		await expect(service.update(previous, next, commit)).resolves.toBe('committed');
+		expect(participant.prepareUpdate).toHaveBeenCalledWith(previous, next, transactionManager);
+		expect(commit).toHaveBeenCalledWith(transactionManager);
+	});
+
+	it('joins the transaction supplied by the primary security orchestrator', async () => {
+		const previous = new UserEntity();
+		const next = new UserEntity();
+		const participant = {
+			prepareUpdate: jest.fn().mockResolvedValue(undefined),
+			prepareRemove: jest.fn().mockResolvedValue(undefined),
+		} as UserLifecycleMutationParticipant;
+		const handler = {
+			update: jest.fn((_previous, _next, commit) => commit(transactionManager)),
+			remove: jest.fn((_user, commit) => commit(transactionManager)),
+		} as UserLifecycleMutationHandler;
+		const commit = jest.fn().mockResolvedValue('committed');
+		service.register(handler);
+		service.registerParticipant(participant);
+
+		await expect(service.update(previous, next, commit)).resolves.toBe('committed');
+		expect(participant.prepareUpdate).toHaveBeenCalledWith(previous, next, transactionManager);
+		expect(commit).toHaveBeenCalledWith(transactionManager);
+	});
+
+	it('rejects duplicate additive participants', () => {
+		const participant = {
+			prepareUpdate: jest.fn(),
+			prepareRemove: jest.fn(),
+		} as unknown as UserLifecycleMutationParticipant;
+		service.registerParticipant(participant);
+
+		expect(() => service.registerParticipant(participant)).toThrow('already registered');
 	});
 });

--- a/apps/backend/src/modules/users/services/user-lifecycle-mutation-registry.service.ts
+++ b/apps/backend/src/modules/users/services/user-lifecycle-mutation-registry.service.ts
@@ -1,4 +1,4 @@
-import { EntityManager } from 'typeorm';
+import { DataSource, EntityManager } from 'typeorm';
 
 import { Injectable } from '@nestjs/common';
 
@@ -11,9 +11,17 @@ export interface UserLifecycleMutationHandler {
 	remove: <T>(user: UserEntity, commit: UserLifecycleCommit<T>) => Promise<T>;
 }
 
+export interface UserLifecycleMutationParticipant {
+	prepareUpdate: (previous: UserEntity, next: UserEntity, manager: EntityManager) => Promise<void>;
+	prepareRemove: (user: UserEntity, manager: EntityManager) => Promise<void>;
+}
+
 @Injectable()
 export class UserLifecycleMutationRegistryService {
 	private handler: UserLifecycleMutationHandler | null = null;
+	private readonly participants = new Set<UserLifecycleMutationParticipant>();
+
+	constructor(private readonly dataSource: DataSource) {}
 
 	register(handler: UserLifecycleMutationHandler): void {
 		if (this.handler) throw new Error('A user lifecycle mutation handler is already registered');
@@ -21,11 +29,56 @@ export class UserLifecycleMutationRegistryService {
 		this.handler = handler;
 	}
 
+	registerParticipant(participant: UserLifecycleMutationParticipant): void {
+		if (this.participants.has(participant))
+			throw new Error('User lifecycle mutation participant is already registered');
+
+		this.participants.add(participant);
+	}
+
 	async update<T>(previous: UserEntity, next: UserEntity, commit: UserLifecycleCommit<T>): Promise<T> {
-		return this.handler ? this.handler.update(previous, next, commit) : commit();
+		if (this.participants.size === 0) return this.handler ? this.handler.update(previous, next, commit) : commit();
+
+		const guardedCommit: UserLifecycleCommit<T> = (manager) =>
+			this.runParticipants(
+				manager,
+				(transactionManager) => this.prepareUpdate(previous, next, transactionManager),
+				commit,
+			);
+
+		return this.handler ? this.handler.update(previous, next, guardedCommit) : guardedCommit();
 	}
 
 	async remove<T>(user: UserEntity, commit: UserLifecycleCommit<T>): Promise<T> {
-		return this.handler ? this.handler.remove(user, commit) : commit();
+		if (this.participants.size === 0) return this.handler ? this.handler.remove(user, commit) : commit();
+
+		const guardedCommit: UserLifecycleCommit<T> = (manager) =>
+			this.runParticipants(manager, (transactionManager) => this.prepareRemove(user, transactionManager), commit);
+
+		return this.handler ? this.handler.remove(user, guardedCommit) : guardedCommit();
+	}
+
+	private async runParticipants<T>(
+		manager: EntityManager | undefined,
+		prepare: (manager: EntityManager) => Promise<void>,
+		commit: UserLifecycleCommit<T>,
+	): Promise<T> {
+		if (manager) {
+			await prepare(manager);
+			return commit(manager);
+		}
+
+		return this.dataSource.transaction(async (transactionManager) => {
+			await prepare(transactionManager);
+			return commit(transactionManager);
+		});
+	}
+
+	private async prepareUpdate(previous: UserEntity, next: UserEntity, manager: EntityManager): Promise<void> {
+		for (const participant of this.participants) await participant.prepareUpdate(previous, next, manager);
+	}
+
+	private async prepareRemove(user: UserEntity, manager: EntityManager): Promise<void> {
+		for (const participant of this.participants) await participant.prepareRemove(user, manager);
 	}
 }

--- a/apps/backend/src/plugins/devices-homey/devices-homey.constants.ts
+++ b/apps/backend/src/plugins/devices-homey/devices-homey.constants.ts
@@ -60,6 +60,14 @@ export const HOMEY_CLOUD_AUTHORIZATION_STATE_TTL_MS = 5 * 60 * 1000;
 
 export const HOMEY_CLOUD_MAX_PENDING_AUTHORIZATIONS = 32;
 
+export const HOMEY_CLOUD_AUTHORIZATION_STATE_KEY = 'primary';
+
+export const HOMEY_CLOUD_ACTIVE_GRANT_KEY = 'primary';
+
+export const HOMEY_CLOUD_PENDING_GRANT_TTL_MS = 10 * 60 * 1000;
+
+export const HOMEY_CLOUD_PENDING_GRANT_CLEANUP_INTERVAL_MS = 60 * 1000;
+
 export enum HomeyConnectionState {
 	STOPPED = 'stopped',
 	CONNECTING = 'connecting',

--- a/apps/backend/src/plugins/devices-homey/devices-homey.plugin.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/devices-homey.plugin.spec.ts
@@ -9,6 +9,7 @@ import { ExtensionsService } from '../../modules/extensions/services/extensions.
 import { PluginServiceManagerService } from '../../modules/extensions/services/plugin-service-manager.service';
 import { ExtendedDiscriminatorService } from '../../modules/swagger/services/extended-discriminator.service';
 import { SwaggerModelsRegistryService } from '../../modules/swagger/services/swagger-models-registry.service';
+import { FactoryResetRegistryService } from '../../modules/system/services/factory-reset-registry.service';
 import { UserLifecycleMutationRegistryService } from '../../modules/users/services/user-lifecycle-mutation-registry.service';
 
 import { HomeyLocalConnectorFactory } from './connectors/homey-local-connector.factory';
@@ -38,7 +39,7 @@ import { HomeySynchronizerService } from './services/homey-synchronizer.service'
 import { HomeyService } from './services/homey.service';
 
 describe('DevicesHomeyPlugin', () => {
-	it('registers config, entities, discriminators, metadata, Swagger models, and managed lifecycle', () => {
+	it('registers config, entities, discriminators, metadata, Swagger models, and managed lifecycle', async () => {
 		const configMapper = { registerMapping: jest.fn() };
 		const devicesMapper = { registerMapping: jest.fn() };
 		const channelsMapper = { registerMapping: jest.fn() };
@@ -51,7 +52,15 @@ describe('DevicesHomeyPlugin', () => {
 		const homeyService = { pluginName: DEVICES_HOMEY_PLUGIN_NAME, serviceId: 'connector' };
 		const homeyDevicePlatform = { getType: () => DEVICES_HOMEY_TYPE };
 		const userLifecycleMutations = { registerParticipant: jest.fn() };
-		const homeyCloudGrantMutations = {};
+		const homeyCloudGrantMutations = { resetForFactory: jest.fn().mockResolvedValue(undefined) };
+		let resetHandler: (() => Promise<{ success: boolean; reason?: string } | null>) | undefined;
+		const factoryResetRegistry = {
+			register: jest.fn(
+				(_name: string, handler: () => Promise<{ success: boolean; reason?: string } | null>, _priority: number) => {
+					resetHandler = handler;
+				},
+			),
+		};
 
 		const plugin = new DevicesHomeyPlugin(
 			configMapper as unknown as PluginsTypeMapperService,
@@ -67,6 +76,7 @@ describe('DevicesHomeyPlugin', () => {
 			homeyDevicePlatform as unknown as HomeyDevicePlatform,
 			userLifecycleMutations as unknown as UserLifecycleMutationRegistryService,
 			homeyCloudGrantMutations as unknown as HomeyCloudGrantMutationService,
+			factoryResetRegistry as unknown as FactoryResetRegistryService,
 		);
 
 		plugin.onModuleInit();
@@ -99,6 +109,10 @@ describe('DevicesHomeyPlugin', () => {
 		expect(pluginServiceManager.register).toHaveBeenCalledWith(homeyService);
 		expect(platformRegistry.register).toHaveBeenCalledWith(homeyDevicePlatform);
 		expect(userLifecycleMutations.registerParticipant).toHaveBeenCalledWith(homeyCloudGrantMutations);
+		expect(factoryResetRegistry.register).toHaveBeenCalledWith(DEVICES_HOMEY_PLUGIN_NAME, expect.any(Function), 190);
+		if (!resetHandler) throw new Error('Homey factory reset handler was not registered');
+		await expect(resetHandler()).resolves.toEqual({ success: true });
+		expect(homeyCloudGrantMutations.resetForFactory).toHaveBeenCalledTimes(1);
 	});
 
 	it('provides a production SDK-backed connector factory through the transport-neutral token', () => {

--- a/apps/backend/src/plugins/devices-homey/devices-homey.plugin.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/devices-homey.plugin.spec.ts
@@ -9,6 +9,7 @@ import { ExtensionsService } from '../../modules/extensions/services/extensions.
 import { PluginServiceManagerService } from '../../modules/extensions/services/plugin-service-manager.service';
 import { ExtendedDiscriminatorService } from '../../modules/swagger/services/extended-discriminator.service';
 import { SwaggerModelsRegistryService } from '../../modules/swagger/services/swagger-models-registry.service';
+import { UserLifecycleMutationRegistryService } from '../../modules/users/services/user-lifecycle-mutation-registry.service';
 
 import { HomeyLocalConnectorFactory } from './connectors/homey-local-connector.factory';
 import { HomeySdkClientFactoryService } from './connectors/homey-sdk.client';
@@ -28,6 +29,7 @@ import { HomeyDevicePlatform } from './platforms/homey-device.platform';
 import { HomeyAdoptionLockService } from './services/homey-adoption-lock.service';
 import { HomeyCloudAuthorizationStateService } from './services/homey-cloud-authorization-state.service';
 import { HomeyCloudClientConfigService } from './services/homey-cloud-client-config.service';
+import { HomeyCloudGrantMutationService } from './services/homey-cloud-grant-mutation.service';
 import { HomeyConnectionTestService } from './services/homey-connection-test.service';
 import { HomeyDeviceAdoptionService } from './services/homey-device-adoption.service';
 import { HomeyDeviceInventoryService } from './services/homey-device-inventory.service';
@@ -48,6 +50,8 @@ describe('DevicesHomeyPlugin', () => {
 		const platformRegistry = { register: jest.fn() };
 		const homeyService = { pluginName: DEVICES_HOMEY_PLUGIN_NAME, serviceId: 'connector' };
 		const homeyDevicePlatform = { getType: () => DEVICES_HOMEY_TYPE };
+		const userLifecycleMutations = { registerParticipant: jest.fn() };
+		const homeyCloudGrantMutations = {};
 
 		const plugin = new DevicesHomeyPlugin(
 			configMapper as unknown as PluginsTypeMapperService,
@@ -61,6 +65,8 @@ describe('DevicesHomeyPlugin', () => {
 			homeyService as unknown as HomeyService,
 			platformRegistry as unknown as PlatformRegistryService,
 			homeyDevicePlatform as unknown as HomeyDevicePlatform,
+			userLifecycleMutations as unknown as UserLifecycleMutationRegistryService,
+			homeyCloudGrantMutations as unknown as HomeyCloudGrantMutationService,
 		);
 
 		plugin.onModuleInit();
@@ -92,6 +98,7 @@ describe('DevicesHomeyPlugin', () => {
 		);
 		expect(pluginServiceManager.register).toHaveBeenCalledWith(homeyService);
 		expect(platformRegistry.register).toHaveBeenCalledWith(homeyDevicePlatform);
+		expect(userLifecycleMutations.registerParticipant).toHaveBeenCalledWith(homeyCloudGrantMutations);
 	});
 
 	it('provides a production SDK-backed connector factory through the transport-neutral token', () => {
@@ -104,6 +111,7 @@ describe('DevicesHomeyPlugin', () => {
 				HomeySdkClientFactoryService,
 				HomeyCloudClientConfigService,
 				HomeyCloudAuthorizationStateService,
+				HomeyCloudGrantMutationService,
 				HomeyLocalConnectorFactory,
 				HomeyConnectionTestService,
 				HomeyMappingLoaderService,

--- a/apps/backend/src/plugins/devices-homey/devices-homey.plugin.ts
+++ b/apps/backend/src/plugins/devices-homey/devices-homey.plugin.ts
@@ -23,6 +23,8 @@ import { ApiTag } from '../../modules/swagger/decorators/api-tag.decorator';
 import { ExtendedDiscriminatorService } from '../../modules/swagger/services/extended-discriminator.service';
 import { SwaggerModelsRegistryService } from '../../modules/swagger/services/swagger-models-registry.service';
 import { SwaggerModule } from '../../modules/swagger/swagger.module';
+import { UserLifecycleMutationRegistryService } from '../../modules/users/services/user-lifecycle-mutation-registry.service';
+import { UsersModule } from '../../modules/users/users.module';
 
 import { HomeyLocalConnectorFactory } from './connectors/homey-local-connector.factory';
 import { HomeySdkClientFactoryService } from './connectors/homey-sdk.client';
@@ -48,6 +50,12 @@ import { HomeyUpdatePluginConfigDto } from './dto/update-config.dto';
 import { UpdateHomeyDeviceDto } from './dto/update-device.dto';
 import { HomeyChannelEntity, HomeyChannelPropertyEntity, HomeyDeviceEntity } from './entities/devices-homey.entity';
 import { HomeyAdoptionLockEntity } from './entities/homey-adoption-lock.entity';
+import {
+	HomeyCloudActiveGrantEntity,
+	HomeyCloudAuthorizationStateEntity,
+	HomeyCloudPendingGrantEntity,
+	HomeyCloudUserAuthorityEntity,
+} from './entities/homey-cloud-grant.entity';
 import { HomeyMappingLoaderService } from './mappings/mapping-loader.service';
 import { HomeyMappingTransformerService } from './mappings/mapping-transformer.service';
 import { HomeyPropertyMappingStorageService } from './mappings/property-mapping-storage.service';
@@ -56,6 +64,7 @@ import { HomeyDevicePlatform } from './platforms/homey-device.platform';
 import { HomeyAdoptionLockService } from './services/homey-adoption-lock.service';
 import { HomeyCloudAuthorizationStateService } from './services/homey-cloud-authorization-state.service';
 import { HomeyCloudClientConfigService } from './services/homey-cloud-client-config.service';
+import { HomeyCloudGrantMutationService } from './services/homey-cloud-grant-mutation.service';
 import { HomeyConfigValidatorService } from './services/homey-config-validator.service';
 import { HomeyConnectionTestService } from './services/homey-connection-test.service';
 import { HomeyDeviceAdoptionService } from './services/homey-device-adoption.service';
@@ -76,17 +85,23 @@ import { HomeyService } from './services/homey.service';
 			HomeyChannelEntity,
 			HomeyChannelPropertyEntity,
 			HomeyAdoptionLockEntity,
+			HomeyCloudAuthorizationStateEntity,
+			HomeyCloudUserAuthorityEntity,
+			HomeyCloudPendingGrantEntity,
+			HomeyCloudActiveGrantEntity,
 		]),
 		DevicesModule,
 		ConfigModule,
 		NestConfigModule,
 		ExtensionsModule,
 		SwaggerModule,
+		UsersModule,
 	],
 	providers: [
 		HomeyConfigValidatorService,
 		HomeyCloudClientConfigService,
 		HomeyCloudAuthorizationStateService,
+		HomeyCloudGrantMutationService,
 		HomeySdkClientFactoryService,
 		HomeyLocalConnectorFactory,
 		{
@@ -136,9 +151,13 @@ export class DevicesHomeyPlugin implements OnModuleInit {
 		private readonly homeyService: HomeyService,
 		private readonly platformRegistry: PlatformRegistryService,
 		private readonly homeyDevicePlatform: HomeyDevicePlatform,
+		private readonly userLifecycleMutations: UserLifecycleMutationRegistryService,
+		private readonly homeyCloudGrantMutations: HomeyCloudGrantMutationService,
 	) {}
 
 	onModuleInit(): void {
+		this.userLifecycleMutations.registerParticipant(this.homeyCloudGrantMutations);
+
 		this.configMapper.registerMapping<HomeyConfigModel, HomeyUpdatePluginConfigDto>({
 			type: DEVICES_HOMEY_PLUGIN_NAME,
 			class: HomeyConfigModel,

--- a/apps/backend/src/plugins/devices-homey/devices-homey.plugin.ts
+++ b/apps/backend/src/plugins/devices-homey/devices-homey.plugin.ts
@@ -23,6 +23,7 @@ import { ApiTag } from '../../modules/swagger/decorators/api-tag.decorator';
 import { ExtendedDiscriminatorService } from '../../modules/swagger/services/extended-discriminator.service';
 import { SwaggerModelsRegistryService } from '../../modules/swagger/services/swagger-models-registry.service';
 import { SwaggerModule } from '../../modules/swagger/swagger.module';
+import { FactoryResetRegistryService } from '../../modules/system/services/factory-reset-registry.service';
 import { UserLifecycleMutationRegistryService } from '../../modules/users/services/user-lifecycle-mutation-registry.service';
 import { UsersModule } from '../../modules/users/users.module';
 
@@ -153,10 +154,25 @@ export class DevicesHomeyPlugin implements OnModuleInit {
 		private readonly homeyDevicePlatform: HomeyDevicePlatform,
 		private readonly userLifecycleMutations: UserLifecycleMutationRegistryService,
 		private readonly homeyCloudGrantMutations: HomeyCloudGrantMutationService,
+		private readonly factoryResetRegistry: FactoryResetRegistryService,
 	) {}
 
 	onModuleInit(): void {
 		this.userLifecycleMutations.registerParticipant(this.homeyCloudGrantMutations);
+		this.factoryResetRegistry.register(
+			DEVICES_HOMEY_PLUGIN_NAME,
+			async (): Promise<{ success: boolean; reason?: string }> => {
+				try {
+					await this.homeyCloudGrantMutations.resetForFactory();
+
+					return { success: true };
+				} catch (error) {
+					return { success: false, reason: error instanceof Error ? error.message : 'Unknown error' };
+				}
+			},
+			// Clear provider credentials before the core Devices and Users reset handlers.
+			190,
+		);
 
 		this.configMapper.registerMapping<HomeyConfigModel, HomeyUpdatePluginConfigDto>({
 			type: DEVICES_HOMEY_PLUGIN_NAME,

--- a/apps/backend/src/plugins/devices-homey/entities/homey-cloud-grant.entity.ts
+++ b/apps/backend/src/plugins/devices-homey/entities/homey-cloud-grant.entity.ts
@@ -10,6 +10,9 @@ export class HomeyCloudAuthorizationStateEntity {
 
 	@Column({ type: 'integer', default: 0 })
 	configurationGeneration!: number;
+
+	@Column({ type: 'varchar', nullable: true })
+	configurationFingerprint!: string | null;
 }
 
 @Entity('devices_homey_cloud_user_authorities')

--- a/apps/backend/src/plugins/devices-homey/entities/homey-cloud-grant.entity.ts
+++ b/apps/backend/src/plugins/devices-homey/entities/homey-cloud-grant.entity.ts
@@ -1,0 +1,119 @@
+import { Column, Entity, Index, PrimaryColumn } from 'typeorm';
+
+@Entity('devices_homey_cloud_authorization_state')
+export class HomeyCloudAuthorizationStateEntity {
+	@PrimaryColumn({ type: 'varchar' })
+	key!: string;
+
+	@Column({ type: 'integer', default: 0 })
+	activeGrantGeneration!: number;
+
+	@Column({ type: 'integer', default: 0 })
+	configurationGeneration!: number;
+}
+
+@Entity('devices_homey_cloud_user_authorities')
+export class HomeyCloudUserAuthorityEntity {
+	@PrimaryColumn({ type: 'varchar' })
+	userId!: string;
+
+	@Column({ type: 'integer', default: 0 })
+	generation!: number;
+}
+
+@Entity('devices_homey_cloud_pending_grants')
+export class HomeyCloudPendingGrantEntity {
+	@PrimaryColumn({ type: 'varchar' })
+	transactionId!: string;
+
+	@Index()
+	@Column({ type: 'varchar' })
+	initiatingUserId!: string;
+
+	@Column({ type: 'integer' })
+	authorityGeneration!: number;
+
+	@Column({ type: 'integer' })
+	activeGrantGeneration!: number;
+
+	@Column({ type: 'integer' })
+	configurationGeneration!: number;
+
+	@Column({ type: 'text' })
+	redirectUrl!: string;
+
+	@Column({ type: 'varchar', select: false })
+	tokenType!: string;
+
+	@Column({ type: 'text', select: false })
+	accessToken!: string;
+
+	@Column({ type: 'text', nullable: true, select: false })
+	refreshToken!: string | null;
+
+	@Column({ type: 'integer', nullable: true, select: false })
+	expiresIn!: number | null;
+
+	@Column({ type: 'varchar', nullable: true, select: false })
+	grantType!: string | null;
+
+	@Column({ type: 'integer', select: false })
+	tokenIssuedAt!: number;
+
+	@Index()
+	@Column({ type: 'integer' })
+	expiresAt!: number;
+
+	@Column({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+	createdAt!: Date | string;
+}
+
+@Entity('devices_homey_cloud_active_grants')
+export class HomeyCloudActiveGrantEntity {
+	@PrimaryColumn({ type: 'varchar' })
+	key!: string;
+
+	@Index({ unique: true })
+	@Column({ type: 'varchar' })
+	grantIdentifier!: string;
+
+	@Index()
+	@Column({ type: 'varchar' })
+	activatedById!: string;
+
+	@Column({ type: 'integer' })
+	authorityGeneration!: number;
+
+	@Column({ type: 'integer' })
+	generation!: number;
+
+	@Column({ type: 'integer' })
+	configurationGeneration!: number;
+
+	@Column({ type: 'varchar' })
+	selectedHomeyId!: string;
+
+	@Column({ type: 'varchar', select: false })
+	tokenType!: string;
+
+	@Column({ type: 'text', select: false })
+	accessToken!: string;
+
+	@Column({ type: 'text', nullable: true, select: false })
+	refreshToken!: string | null;
+
+	@Column({ type: 'integer', nullable: true, select: false })
+	expiresIn!: number | null;
+
+	@Column({ type: 'varchar', nullable: true, select: false })
+	grantType!: string | null;
+
+	@Column({ type: 'integer', select: false })
+	tokenIssuedAt!: number;
+
+	@Column({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+	activatedAt!: Date | string;
+
+	@Column({ type: 'datetime', nullable: true })
+	updatedAt!: Date | string | null;
+}

--- a/apps/backend/src/plugins/devices-homey/errors/homey-cloud-grant.error.ts
+++ b/apps/backend/src/plugins/devices-homey/errors/homey-cloud-grant.error.ts
@@ -1,0 +1,20 @@
+export class HomeyCloudGrantConflictError extends Error {
+	constructor() {
+		super('Homey Cloud authorization transaction is invalid, expired, or no longer current');
+		this.name = 'HomeyCloudGrantConflictError';
+	}
+}
+
+export class HomeyCloudGrantAuthorityError extends Error {
+	constructor() {
+		super('Homey Cloud authorization authority is no longer valid');
+		this.name = 'HomeyCloudGrantAuthorityError';
+	}
+}
+
+export class HomeyCloudGrantStateError extends Error {
+	constructor() {
+		super('Homey Cloud authorization persistence is unavailable');
+		this.name = 'HomeyCloudGrantStateError';
+	}
+}

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization-state.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization-state.service.spec.ts
@@ -24,6 +24,7 @@ describe('HomeyCloudAuthorizationStateService', () => {
 	const start = {
 		activeGrantGeneration: 7,
 		authorityGeneration: 3,
+		configurationGeneration: 2,
 		initiatingUserId: 'user-id',
 	};
 
@@ -105,6 +106,7 @@ describe('HomeyCloudAuthorizationStateService', () => {
 		{ ...start, initiatingUserId: '' },
 		{ ...start, authorityGeneration: -1 },
 		{ ...start, activeGrantGeneration: Number.NaN },
+		{ ...start, configurationGeneration: -1 },
 	])('rejects an invalid authorization context', (context) => {
 		expect(() => service.create(context)).toThrow(TypeError);
 	});

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization-state.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization-state.service.ts
@@ -18,6 +18,7 @@ import { HomeyCloudClientConfigService } from './homey-cloud-client-config.servi
 interface PendingAuthorizationState {
 	readonly activeGrantGeneration: number;
 	readonly authorityGeneration: number;
+	readonly configurationGeneration: number;
 	readonly expiresAt: number;
 	readonly initiatingUserId: string;
 	readonly redirectUrl: string;
@@ -28,6 +29,7 @@ interface PendingAuthorizationState {
 export interface HomeyCloudAuthorizationStart {
 	readonly activeGrantGeneration: number;
 	readonly authorityGeneration: number;
+	readonly configurationGeneration: number;
 	readonly initiatingUserId: string;
 }
 
@@ -40,6 +42,7 @@ export interface HomeyCloudAuthorizationFlow {
 export interface HomeyCloudConsumedAuthorization {
 	readonly activeGrantGeneration: number;
 	readonly authorityGeneration: number;
+	readonly configurationGeneration: number;
 	readonly expiresAt: Date;
 	readonly initiatingUserId: string;
 	readonly redirectUrl: string;
@@ -81,6 +84,7 @@ export class HomeyCloudAuthorizationStateService implements OnModuleDestroy {
 		this.pending.set(stateHash, {
 			activeGrantGeneration: start.activeGrantGeneration,
 			authorityGeneration: start.authorityGeneration,
+			configurationGeneration: start.configurationGeneration,
 			expiresAt,
 			initiatingUserId: start.initiatingUserId,
 			redirectUrl: configuration.redirectUrl,
@@ -111,6 +115,7 @@ export class HomeyCloudAuthorizationStateService implements OnModuleDestroy {
 		return {
 			activeGrantGeneration: pending.activeGrantGeneration,
 			authorityGeneration: pending.authorityGeneration,
+			configurationGeneration: pending.configurationGeneration,
 			expiresAt: new Date(pending.expiresAt),
 			initiatingUserId: pending.initiatingUserId,
 			redirectUrl: pending.redirectUrl,
@@ -131,7 +136,9 @@ export class HomeyCloudAuthorizationStateService implements OnModuleDestroy {
 			!Number.isSafeInteger(start.authorityGeneration) ||
 			start.authorityGeneration < 0 ||
 			!Number.isSafeInteger(start.activeGrantGeneration) ||
-			start.activeGrantGeneration < 0
+			start.activeGrantGeneration < 0 ||
+			!Number.isSafeInteger(start.configurationGeneration) ||
+			start.configurationGeneration < 0
 		) {
 			throw new TypeError('Homey Cloud authorization start context is invalid');
 		}

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-client-config.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-client-config.service.spec.ts
@@ -32,6 +32,17 @@ describe('HomeyCloudClientConfigService', () => {
 		expect(create().isConfigured()).toBe(true);
 	});
 
+	it('creates a stable non-secret identity for the complete OAuth client configuration', () => {
+		const fingerprint = create().getConfigurationFingerprint();
+
+		expect(fingerprint).toMatch(/^[a-f0-9]{64}$/);
+		expect(create().getConfigurationFingerprint()).toBe(fingerprint);
+		expect(
+			create({ ...valid, [HOMEY_CLOUD_CLIENT_SECRET_ENV]: 'rotated-secret' }).getConfigurationFingerprint(),
+		).not.toBe(fingerprint);
+		expect(fingerprint).not.toContain('client-secret');
+	});
+
 	it.each([HOMEY_CLOUD_CLIENT_ID_ENV, HOMEY_CLOUD_CLIENT_SECRET_ENV, HOMEY_CLOUD_REDIRECT_URL_ENV])(
 		'fails closed when %s is missing',
 		(key) => {
@@ -39,6 +50,7 @@ describe('HomeyCloudClientConfigService', () => {
 
 			expect(() => service.getConfiguration()).toThrow(HomeyCloudConfigurationError);
 			expect(service.isConfigured()).toBe(false);
+			expect(service.getConfigurationFingerprint()).toBeNull();
 		},
 	);
 

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-client-config.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-client-config.service.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 import { Injectable } from '@nestjs/common';
 import { ConfigService as NestConfigService } from '@nestjs/config';
 
@@ -6,6 +8,7 @@ import {
 	HOMEY_CLOUD_CLIENT_ID_ENV,
 	HOMEY_CLOUD_CLIENT_SECRET_ENV,
 	HOMEY_CLOUD_REDIRECT_URL_ENV,
+	HOMEY_CLOUD_SCOPES,
 } from '../devices-homey.constants';
 import { HomeyCloudConfigurationError } from '../errors/homey-cloud-authorization.error';
 
@@ -39,6 +42,19 @@ export class HomeyCloudClientConfigService {
 		this.assertRedirectUrl(redirectUrl);
 
 		return { clientId, clientSecret, redirectUrl };
+	}
+
+	getConfigurationFingerprint(): string | null {
+		try {
+			const configuration = this.getConfiguration();
+			const identity = JSON.stringify({ ...configuration, scopes: HOMEY_CLOUD_SCOPES });
+
+			return createHash('sha256').update(identity).digest('hex');
+		} catch (error) {
+			if (error instanceof HomeyCloudConfigurationError) return null;
+
+			throw error;
+		}
 	}
 
 	private readRequired(key: string): string {

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-grant-mutation.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-grant-mutation.service.spec.ts
@@ -229,24 +229,6 @@ describe('HomeyCloudGrantMutationService', () => {
 		});
 	});
 
-	it('reconciles a changed deployment configuration during application bootstrap', async () => {
-		const context = await service.getAuthorizationContext(administratorId);
-		await service.stageCandidate(candidateInput(context, 'startup-configuration', token('stale')));
-		await service.activateCandidate('startup-configuration', administratorId, 'homey-one');
-		configurationFingerprint = 'configuration-after-restart';
-
-		await service.onApplicationBootstrap();
-
-		await expect(
-			dataSource.getRepository(HomeyCloudActiveGrantEntity).findOneBy({ key: HOMEY_CLOUD_ACTIVE_GRANT_KEY }),
-		).resolves.toBeNull();
-		await expect(
-			dataSource.getRepository(HomeyCloudAuthorizationStateEntity).findOneByOrFail({
-				key: HOMEY_CLOUD_AUTHORIZATION_STATE_KEY,
-			}),
-		).resolves.toMatchObject({ configurationFingerprint: 'configuration-after-restart' });
-	});
-
 	it('invalidates the active grant in the same transaction as its activating user removal', async () => {
 		const context = await service.getAuthorizationContext(administratorId);
 		await service.stageCandidate(candidateInput(context, 'removal-transaction', token('active')));

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-grant-mutation.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-grant-mutation.service.spec.ts
@@ -276,6 +276,29 @@ describe('HomeyCloudGrantMutationService', () => {
 		await expect(service.loadActiveGrantCredentials()).resolves.toBeNull();
 	});
 
+	it('clears every persisted credential and authority record during factory reset', async () => {
+		const context = await service.getAuthorizationContext(administratorId);
+		await service.stageCandidate(candidateInput(context, 'factory-active', token('active')));
+		const active = await service.activateCandidate('factory-active', administratorId, 'homey-one');
+		const pendingContext = await service.getAuthorizationContext(otherAdministratorId);
+		await service.stageCandidate(candidateInput(pendingContext, 'factory-pending', token('pending')));
+
+		await service.resetForFactory();
+
+		await expect(dataSource.getRepository(HomeyCloudPendingGrantEntity).count()).resolves.toBe(0);
+		await expect(dataSource.getRepository(HomeyCloudActiveGrantEntity).count()).resolves.toBe(0);
+		await expect(dataSource.getRepository(HomeyCloudUserAuthorityEntity).count()).resolves.toBe(0);
+		await expect(
+			dataSource.getRepository(HomeyCloudAuthorizationStateEntity).findOneByOrFail({
+				key: HOMEY_CLOUD_AUTHORIZATION_STATE_KEY,
+			}),
+		).resolves.toMatchObject({
+			activeGrantGeneration: active.generation + 1,
+			configurationGeneration: active.configurationGeneration + 1,
+			configurationFingerprint,
+		});
+	});
+
 	function candidateInput(
 		context: Awaited<ReturnType<HomeyCloudGrantMutationService['getAuthorizationContext']>>,
 		transactionId: string,

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-grant-mutation.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-grant-mutation.service.spec.ts
@@ -16,6 +16,7 @@ import {
 import { HomeyCloudAuthorizationCapacityError } from '../errors/homey-cloud-authorization.error';
 import { HomeyCloudGrantAuthorityError, HomeyCloudGrantConflictError } from '../errors/homey-cloud-grant.error';
 
+import { HomeyCloudClientConfigService } from './homey-cloud-client-config.service';
 import { HomeyCloudGrantMutationService, HomeyCloudTokenMaterial } from './homey-cloud-grant-mutation.service';
 
 describe('HomeyCloudGrantMutationService', () => {
@@ -23,8 +24,10 @@ describe('HomeyCloudGrantMutationService', () => {
 	const otherAdministratorId = '22222222-2222-4222-8222-222222222222';
 	let dataSource: DataSource;
 	let service: HomeyCloudGrantMutationService;
+	let configurationFingerprint: string | null;
 
 	beforeEach(async () => {
+		configurationFingerprint = 'configuration-one';
 		dataSource = new DataSource({
 			type: 'sqlite',
 			database: ':memory:',
@@ -40,7 +43,9 @@ describe('HomeyCloudGrantMutationService', () => {
 		await dataSource.initialize();
 		await createUser(administratorId, 'administrator');
 		await createUser(otherAdministratorId, 'other-administrator');
-		service = new HomeyCloudGrantMutationService(dataSource);
+		service = new HomeyCloudGrantMutationService(dataSource, {
+			getConfigurationFingerprint: jest.fn(() => configurationFingerprint),
+		} as unknown as HomeyCloudClientConfigService);
 	});
 
 	afterEach(async () => {
@@ -202,7 +207,44 @@ describe('HomeyCloudGrantMutationService', () => {
 			dataSource.getRepository(HomeyCloudAuthorizationStateEntity).findOneByOrFail({
 				key: HOMEY_CLOUD_AUTHORIZATION_STATE_KEY,
 			}),
-		).resolves.toMatchObject({ activeGrantGeneration: 2, configurationGeneration: 1 });
+		).resolves.toMatchObject({ activeGrantGeneration: 3, configurationGeneration: 2 });
+	});
+
+	it('invalidates persisted credentials before loading them under changed deployment configuration', async () => {
+		const context = await service.getAuthorizationContext(administratorId);
+		await service.stageCandidate(candidateInput(context, 'stale-configuration', token('stale')));
+		const active = await service.activateCandidate('stale-configuration', administratorId, 'homey-one');
+
+		configurationFingerprint = 'configuration-two';
+
+		await expect(service.loadActiveGrantCredentials()).resolves.toBeNull();
+		await expect(
+			dataSource.getRepository(HomeyCloudAuthorizationStateEntity).findOneByOrFail({
+				key: HOMEY_CLOUD_AUTHORIZATION_STATE_KEY,
+			}),
+		).resolves.toMatchObject({
+			activeGrantGeneration: active.generation + 1,
+			configurationGeneration: active.configurationGeneration + 1,
+			configurationFingerprint: 'configuration-two',
+		});
+	});
+
+	it('reconciles a changed deployment configuration during application bootstrap', async () => {
+		const context = await service.getAuthorizationContext(administratorId);
+		await service.stageCandidate(candidateInput(context, 'startup-configuration', token('stale')));
+		await service.activateCandidate('startup-configuration', administratorId, 'homey-one');
+		configurationFingerprint = 'configuration-after-restart';
+
+		await service.onApplicationBootstrap();
+
+		await expect(
+			dataSource.getRepository(HomeyCloudActiveGrantEntity).findOneBy({ key: HOMEY_CLOUD_ACTIVE_GRANT_KEY }),
+		).resolves.toBeNull();
+		await expect(
+			dataSource.getRepository(HomeyCloudAuthorizationStateEntity).findOneByOrFail({
+				key: HOMEY_CLOUD_AUTHORIZATION_STATE_KEY,
+			}),
+		).resolves.toMatchObject({ configurationFingerprint: 'configuration-after-restart' });
 	});
 
 	it('invalidates the active grant in the same transaction as its activating user removal', async () => {

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-grant-mutation.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-grant-mutation.service.spec.ts
@@ -1,0 +1,292 @@
+import { DataSource } from 'typeorm';
+
+import { UserEntity } from '../../../modules/users/entities/users.entity';
+import { UserRole } from '../../../modules/users/users.constants';
+import {
+	HOMEY_CLOUD_ACTIVE_GRANT_KEY,
+	HOMEY_CLOUD_AUTHORIZATION_STATE_KEY,
+	HOMEY_CLOUD_MAX_PENDING_AUTHORIZATIONS,
+} from '../devices-homey.constants';
+import {
+	HomeyCloudActiveGrantEntity,
+	HomeyCloudAuthorizationStateEntity,
+	HomeyCloudPendingGrantEntity,
+	HomeyCloudUserAuthorityEntity,
+} from '../entities/homey-cloud-grant.entity';
+import { HomeyCloudAuthorizationCapacityError } from '../errors/homey-cloud-authorization.error';
+import { HomeyCloudGrantAuthorityError, HomeyCloudGrantConflictError } from '../errors/homey-cloud-grant.error';
+
+import { HomeyCloudGrantMutationService, HomeyCloudTokenMaterial } from './homey-cloud-grant-mutation.service';
+
+describe('HomeyCloudGrantMutationService', () => {
+	const administratorId = '11111111-1111-4111-8111-111111111111';
+	const otherAdministratorId = '22222222-2222-4222-8222-222222222222';
+	let dataSource: DataSource;
+	let service: HomeyCloudGrantMutationService;
+
+	beforeEach(async () => {
+		dataSource = new DataSource({
+			type: 'sqlite',
+			database: ':memory:',
+			entities: [
+				UserEntity,
+				HomeyCloudAuthorizationStateEntity,
+				HomeyCloudUserAuthorityEntity,
+				HomeyCloudPendingGrantEntity,
+				HomeyCloudActiveGrantEntity,
+			],
+			synchronize: true,
+		});
+		await dataSource.initialize();
+		await createUser(administratorId, 'administrator');
+		await createUser(otherAdministratorId, 'other-administrator');
+		service = new HomeyCloudGrantMutationService(dataSource);
+	});
+
+	afterEach(async () => {
+		service.onModuleDestroy();
+		await dataSource.destroy();
+	});
+
+	it('persists isolated candidate credentials behind explicit secret reads', async () => {
+		const context = await service.getAuthorizationContext(administratorId);
+		const candidate = candidateInput(context, 'transaction-one', token('candidate'));
+		const { expiresAt } = await service.stageCandidate(candidate);
+		const ordinaryRead = await dataSource
+			.getRepository(HomeyCloudPendingGrantEntity)
+			.findOneByOrFail({ transactionId: candidate.transactionId });
+
+		expect(ordinaryRead.accessToken).toBeUndefined();
+		expect(ordinaryRead.refreshToken).toBeUndefined();
+		expect(ordinaryRead.tokenType).toBeUndefined();
+		await expect(service.loadCandidateCredentials(candidate.transactionId, administratorId)).resolves.toEqual({
+			...candidate,
+			expiresAt,
+		});
+	});
+
+	it('keeps the active grant until a generation-matched candidate activates atomically', async () => {
+		const firstContext = await service.getAuthorizationContext(administratorId);
+		await service.stageCandidate(candidateInput(firstContext, 'first-transaction', token('first')));
+		const first = await service.activateCandidate('first-transaction', administratorId, 'homey-one');
+		const replacementContext = await service.getAuthorizationContext(otherAdministratorId);
+		await service.stageCandidate(candidateInput(replacementContext, 'replacement-transaction', token('replacement')));
+
+		await expect(service.loadActiveGrantCredentials()).resolves.toEqual({ ...first, token: token('first') });
+
+		const replacement = await service.activateCandidate('replacement-transaction', otherAdministratorId, 'homey-two');
+
+		expect(replacement.generation).toBe(first.generation + 1);
+		await expect(service.loadActiveGrantCredentials()).resolves.toEqual({
+			...replacement,
+			token: token('replacement'),
+		});
+		await expect(dataSource.getRepository(HomeyCloudPendingGrantEntity).count()).resolves.toBe(0);
+	});
+
+	it('clears a candidate that loses its authority generation before activation', async () => {
+		const context = await service.getAuthorizationContext(administratorId);
+		await service.stageCandidate(candidateInput(context, 'demoted-transaction', token('demoted')));
+		await service.invalidateUserAuthority(administratorId, async (manager) => {
+			await manager.getRepository(UserEntity).update({ id: administratorId }, { role: UserRole.USER });
+		});
+
+		await expect(service.activateCandidate('demoted-transaction', administratorId, 'homey-one')).rejects.toThrow(
+			HomeyCloudGrantConflictError,
+		);
+		await expect(dataSource.getRepository(HomeyCloudPendingGrantEntity).count()).resolves.toBe(0);
+		await expect(service.loadActiveGrantCredentials()).resolves.toBeNull();
+	});
+
+	it('discards a late refresh instead of overwriting a newer rotated token', async () => {
+		const context = await service.getAuthorizationContext(administratorId);
+		await service.stageCandidate(candidateInput(context, 'refresh-transaction', token('original')));
+		const active = await service.activateCandidate('refresh-transaction', administratorId, 'homey-one');
+		const refreshedToken = token('refreshed');
+		const refreshed = await service.persistRefresh({
+			grantIdentifier: active.grantIdentifier,
+			generation: active.generation,
+			configurationGeneration: active.configurationGeneration,
+			token: refreshedToken,
+		});
+
+		expect(refreshed?.generation).toBe(active.generation + 1);
+		await expect(
+			service.persistRefresh({
+				grantIdentifier: active.grantIdentifier,
+				generation: active.generation,
+				configurationGeneration: active.configurationGeneration,
+				token: token('late'),
+			}),
+		).resolves.toBeNull();
+		await expect(service.loadActiveGrantCredentials()).resolves.toEqual({
+			...refreshed,
+			token: refreshedToken,
+		});
+	});
+
+	it('serializes cancellation ahead of activation and never restores the removed candidate', async () => {
+		const context = await service.getAuthorizationContext(administratorId);
+		await service.stageCandidate(candidateInput(context, 'cancelled-transaction', token('cancelled')));
+
+		const cancellation = service.cancelCandidate('cancelled-transaction', administratorId);
+		const activation = service.activateCandidate('cancelled-transaction', administratorId, 'homey-one');
+
+		await expect(cancellation).resolves.toBe(true);
+		await expect(activation).rejects.toThrow(HomeyCloudGrantConflictError);
+		await expect(service.loadActiveGrantCredentials()).resolves.toBeNull();
+	});
+
+	it('expires abandoned candidates at their original absolute deadline', async () => {
+		const context = await service.getAuthorizationContext(administratorId);
+		const expiresAt = Date.now() + 100;
+		await service.stageCandidate({
+			...candidateInput(context, 'expiring-transaction', token('expiring')),
+			expiresAt,
+		});
+
+		await expect(service.expireCandidates(expiresAt)).resolves.toBe(1);
+		await expect(service.loadCandidateCredentials('expiring-transaction', administratorId)).rejects.toThrow(
+			HomeyCloudGrantConflictError,
+		);
+	});
+
+	it('rejects a caller-controlled candidate lifetime beyond the server limit', async () => {
+		const context = await service.getAuthorizationContext(administratorId);
+
+		await expect(
+			service.stageCandidate({
+				...candidateInput(context, 'unbounded-transaction', token('unbounded')),
+				expiresAt: Date.now() + 60 * 60 * 1000,
+			}),
+		).rejects.toThrow(HomeyCloudGrantConflictError);
+	});
+
+	it('bounds persistent candidates after expired records are swept', async () => {
+		const context = await service.getAuthorizationContext(administratorId);
+
+		for (let index = 0; index < HOMEY_CLOUD_MAX_PENDING_AUTHORIZATIONS; index += 1) {
+			await service.stageCandidate(candidateInput(context, `bounded-${index}`, token(`bounded-${index}`)));
+		}
+
+		await expect(
+			service.stageCandidate(candidateInput(context, 'over-capacity', token('over-capacity'))),
+		).rejects.toThrow(HomeyCloudAuthorizationCapacityError);
+	});
+
+	it('rechecks current authority before disconnect and retains the active grant on rejection', async () => {
+		const context = await service.getAuthorizationContext(administratorId);
+		await service.stageCandidate(candidateInput(context, 'disconnect-transaction', token('active')));
+		await service.activateCandidate('disconnect-transaction', administratorId, 'homey-one');
+		await dataSource.getRepository(UserEntity).update({ id: otherAdministratorId }, { role: UserRole.USER });
+
+		await expect(service.disconnect(otherAdministratorId)).rejects.toThrow(HomeyCloudGrantAuthorityError);
+		await expect(service.loadActiveGrantCredentials()).resolves.not.toBeNull();
+		await expect(service.disconnect(administratorId)).resolves.toBe(true);
+		await expect(service.loadActiveGrantCredentials()).resolves.toBeNull();
+	});
+
+	it('rolls back configuration invalidation when its configuration commit fails', async () => {
+		const context = await service.getAuthorizationContext(administratorId);
+		await service.stageCandidate(candidateInput(context, 'config-transaction', token('active')));
+		const active = await service.activateCandidate('config-transaction', administratorId, 'homey-one');
+
+		await expect(
+			service.invalidateConfiguration(() => Promise.reject(new Error('configuration write failed'))),
+		).rejects.toThrow('configuration write failed');
+		await expect(service.loadActiveGrantCredentials()).resolves.toEqual({ ...active, token: token('active') });
+
+		await expect(service.invalidateConfiguration(() => Promise.resolve('committed'))).resolves.toBe('committed');
+		await expect(service.loadActiveGrantCredentials()).resolves.toBeNull();
+		await expect(
+			dataSource.getRepository(HomeyCloudAuthorizationStateEntity).findOneByOrFail({
+				key: HOMEY_CLOUD_AUTHORIZATION_STATE_KEY,
+			}),
+		).resolves.toMatchObject({ activeGrantGeneration: 2, configurationGeneration: 1 });
+	});
+
+	it('invalidates the active grant in the same transaction as its activating user removal', async () => {
+		const context = await service.getAuthorizationContext(administratorId);
+		await service.stageCandidate(candidateInput(context, 'removal-transaction', token('active')));
+		await service.activateCandidate('removal-transaction', administratorId, 'homey-one');
+
+		await service.invalidateUserAuthority(administratorId, (manager) =>
+			manager
+				.getRepository(UserEntity)
+				.delete({ id: administratorId })
+				.then(() => undefined),
+		);
+
+		await expect(service.loadActiveGrantCredentials()).resolves.toBeNull();
+		await expect(
+			dataSource.getRepository(HomeyCloudUserAuthorityEntity).findOneByOrFail({ userId: administratorId }),
+		).resolves.toMatchObject({ generation: 1 });
+		await expect(
+			dataSource.getRepository(HomeyCloudActiveGrantEntity).findOneBy({ key: HOMEY_CLOUD_ACTIVE_GRANT_KEY }),
+		).resolves.toBeNull();
+	});
+
+	it('rolls back user-authority invalidation when the user mutation fails', async () => {
+		const context = await service.getAuthorizationContext(administratorId);
+		await service.stageCandidate(candidateInput(context, 'failed-demotion', token('active')));
+		const active = await service.activateCandidate('failed-demotion', administratorId, 'homey-one');
+
+		await expect(
+			service.invalidateUserAuthority(administratorId, () => Promise.reject(new Error('user update failed'))),
+		).rejects.toThrow('user update failed');
+		await expect(service.loadActiveGrantCredentials()).resolves.toEqual({ ...active, token: token('active') });
+		await expect(
+			dataSource.getRepository(HomeyCloudUserAuthorityEntity).findOneByOrFail({ userId: administratorId }),
+		).resolves.toMatchObject({ generation: 0 });
+	});
+
+	it('prepares an administrator demotion through the additive user lifecycle boundary', async () => {
+		const context = await service.getAuthorizationContext(administratorId);
+		await service.stageCandidate(candidateInput(context, 'participant-demotion', token('active')));
+		await service.activateCandidate('participant-demotion', administratorId, 'homey-one');
+		const previous = await dataSource.getRepository(UserEntity).findOneByOrFail({ id: administratorId });
+		const next = Object.assign(new UserEntity(), previous, { role: UserRole.USER });
+
+		await dataSource.transaction((manager) => service.prepareUpdate(previous, next, manager));
+
+		await expect(service.loadActiveGrantCredentials()).resolves.toBeNull();
+	});
+
+	function candidateInput(
+		context: Awaited<ReturnType<HomeyCloudGrantMutationService['getAuthorizationContext']>>,
+		transactionId: string,
+		material: HomeyCloudTokenMaterial,
+	) {
+		return {
+			...context,
+			transactionId,
+			redirectUrl: 'https://panel.example.com/api/v1/plugins/devices-homey/oauth/callback',
+			token: material,
+		};
+	}
+
+	function token(suffix: string): HomeyCloudTokenMaterial {
+		return {
+			tokenType: 'bearer',
+			accessToken: `access-${suffix}`,
+			refreshToken: `refresh-${suffix}`,
+			expiresIn: 3600,
+			grantType: 'authorization_code',
+			issuedAt: 1_777_777_777_000,
+		};
+	}
+
+	async function createUser(id: string, username: string): Promise<void> {
+		await dataSource.getRepository(UserEntity).save({
+			id,
+			username,
+			role: UserRole.ADMIN,
+			isHidden: false,
+			password: null,
+			email: null,
+			firstName: null,
+			lastName: null,
+			language: null,
+		});
+	}
+});

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-grant-mutation.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-grant-mutation.service.ts
@@ -370,6 +370,22 @@ export class HomeyCloudGrantMutationService
 		);
 	}
 
+	async resetForFactory(): Promise<void> {
+		await this.runMutation(() =>
+			this.dataSource.transaction(async (manager) => {
+				const state = await this.getState(manager);
+
+				await manager.getRepository(HomeyCloudPendingGrantEntity).clear();
+				await manager.getRepository(HomeyCloudActiveGrantEntity).clear();
+				await manager.getRepository(HomeyCloudUserAuthorityEntity).clear();
+				await this.advanceState(manager, state, {
+					activeGrantGeneration: state.activeGrantGeneration + 1,
+					configurationGeneration: state.configurationGeneration + 1,
+				});
+			}),
+		);
+	}
+
 	async prepareUpdate(previous: UserEntity, next: UserEntity, manager: EntityManager): Promise<void> {
 		const wasAuthorized = AUTHORIZED_ROLES.includes(previous.role);
 		const remainsAuthorized = AUTHORIZED_ROLES.includes(next.role);

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-grant-mutation.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-grant-mutation.service.ts
@@ -26,6 +26,8 @@ import {
 	HomeyCloudGrantStateError,
 } from '../errors/homey-cloud-grant.error';
 
+import { HomeyCloudClientConfigService } from './homey-cloud-client-config.service';
+
 const AUTHORIZED_ROLES = [UserRole.OWNER, UserRole.ADMIN];
 
 export interface HomeyCloudTokenMaterial {
@@ -89,9 +91,13 @@ export class HomeyCloudGrantMutationService
 	private mutationTail: Promise<void> = Promise.resolve();
 	private cleanupTimer: NodeJS.Timeout | null = null;
 
-	constructor(private readonly dataSource: DataSource) {}
+	constructor(
+		private readonly dataSource: DataSource,
+		private readonly clientConfig: HomeyCloudClientConfigService,
+	) {}
 
-	onApplicationBootstrap(): void {
+	async onApplicationBootstrap(): Promise<void> {
+		await this.reconcileConfiguration();
 		this.cleanupTimer = setInterval(() => {
 			void this.expireCandidates().catch(() => {
 				this.logger.warn('Homey Cloud pending grant cleanup is temporarily unavailable');
@@ -111,7 +117,7 @@ export class HomeyCloudGrantMutationService
 		return this.runMutation(() =>
 			this.dataSource.transaction(async (manager) => {
 				await this.requireAuthorizedUser(manager, initiatingUserId);
-				const state = await this.getState(manager);
+				const state = await this.reconcileConfigurationInternal(manager);
 				const authorityGeneration = await this.getOrCreateAuthorityGeneration(manager, initiatingUserId);
 
 				return {
@@ -138,7 +144,7 @@ export class HomeyCloudGrantMutationService
 			this.dataSource.transaction(async (manager) => {
 				await this.deleteExpiredCandidates(manager, now);
 				await this.requireCurrentAuthority(manager, input.initiatingUserId, input.authorityGeneration);
-				const state = await this.getState(manager);
+				const state = await this.reconcileConfigurationInternal(manager);
 
 				if (
 					state.activeGrantGeneration !== input.activeGrantGeneration ||
@@ -187,6 +193,7 @@ export class HomeyCloudGrantMutationService
 		return this.runMutation(() =>
 			this.dataSource.transaction(async (manager) => {
 				const now = Date.now();
+				await this.reconcileConfigurationInternal(manager);
 				await this.deleteExpiredCandidates(manager, now);
 				const candidate = await this.findCandidateWithCredentials(manager, transactionId, initiatingUserId);
 
@@ -241,11 +248,14 @@ export class HomeyCloudGrantMutationService
 	}
 
 	async loadActiveGrantCredentials(): Promise<HomeyCloudActiveGrantCredentials | null> {
-		return this.runMutation(async () => {
-			const active = await this.findActiveGrantWithCredentials(this.dataSource.manager);
+		return this.runMutation(() =>
+			this.dataSource.transaction(async (manager) => {
+				await this.reconcileConfigurationInternal(manager);
+				const active = await this.findActiveGrantWithCredentials(manager);
 
-			return active ? this.toActiveCredentials(active) : null;
-		});
+				return active ? this.toActiveCredentials(active) : null;
+			}),
+		);
 	}
 
 	async persistRefresh(input: HomeyCloudRefreshInput): Promise<HomeyCloudActiveGrantReference | null> {
@@ -256,7 +266,7 @@ export class HomeyCloudGrantMutationService
 
 		return this.runMutation(() =>
 			this.dataSource.transaction(async (manager) => {
-				const state = await this.getState(manager);
+				const state = await this.reconcileConfigurationInternal(manager);
 
 				if (
 					state.activeGrantGeneration !== input.generation ||
@@ -318,7 +328,7 @@ export class HomeyCloudGrantMutationService
 		return this.runMutation(() =>
 			this.dataSource.transaction(async (manager) => {
 				await this.requireAuthorizedUser(manager, actingUserId);
-				const state = await this.getState(manager);
+				const state = await this.reconcileConfigurationInternal(manager);
 				const result = await manager
 					.getRepository(HomeyCloudActiveGrantEntity)
 					.delete({ key: HOMEY_CLOUD_ACTIVE_GRANT_KEY });
@@ -391,7 +401,7 @@ export class HomeyCloudGrantMutationService
 			userId: initiatingUserId,
 		});
 		const authorityGeneration = authority?.generation ?? 0;
-		const state = await this.getState(manager);
+		const state = await this.reconcileConfigurationInternal(manager);
 		const authorized = user !== null && AUTHORIZED_ROLES.includes(user.role);
 		const authorityCurrent = authorityGeneration === candidate.authorityGeneration;
 		const generationsCurrent =
@@ -446,6 +456,7 @@ export class HomeyCloudGrantMutationService
 				key: HOMEY_CLOUD_AUTHORIZATION_STATE_KEY,
 				activeGrantGeneration: 0,
 				configurationGeneration: 0,
+				configurationFingerprint: null,
 			});
 			state = await states.findOneBy({ key: HOMEY_CLOUD_AUTHORIZATION_STATE_KEY });
 		}
@@ -458,7 +469,12 @@ export class HomeyCloudGrantMutationService
 	private async advanceState(
 		manager: EntityManager,
 		state: HomeyCloudAuthorizationStateEntity,
-		update: Partial<Pick<HomeyCloudAuthorizationStateEntity, 'activeGrantGeneration' | 'configurationGeneration'>>,
+		update: Partial<
+			Pick<
+				HomeyCloudAuthorizationStateEntity,
+				'activeGrantGeneration' | 'configurationFingerprint' | 'configurationGeneration'
+			>
+		>,
 	): Promise<void> {
 		const result = await manager.getRepository(HomeyCloudAuthorizationStateEntity).update(
 			{
@@ -470,6 +486,32 @@ export class HomeyCloudGrantMutationService
 		);
 
 		if (result.affected !== 1) throw new HomeyCloudGrantStateError();
+	}
+
+	private async reconcileConfiguration(): Promise<void> {
+		await this.runMutation(() =>
+			this.dataSource.transaction(async (manager) => {
+				await this.reconcileConfigurationInternal(manager);
+			}),
+		);
+	}
+
+	private async reconcileConfigurationInternal(manager: EntityManager): Promise<HomeyCloudAuthorizationStateEntity> {
+		const state = await this.getState(manager);
+		const configurationFingerprint = this.clientConfig.getConfigurationFingerprint();
+
+		if (state.configurationFingerprint === configurationFingerprint) return state;
+
+		await manager.getRepository(HomeyCloudPendingGrantEntity).clear();
+		await manager.getRepository(HomeyCloudActiveGrantEntity).clear();
+		const update = {
+			activeGrantGeneration: state.activeGrantGeneration + 1,
+			configurationGeneration: state.configurationGeneration + 1,
+			configurationFingerprint,
+		};
+		await this.advanceState(manager, state, update);
+
+		return { ...state, ...update };
 	}
 
 	private async requireCurrentAuthority(

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-grant-mutation.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-grant-mutation.service.ts
@@ -96,8 +96,7 @@ export class HomeyCloudGrantMutationService
 		private readonly clientConfig: HomeyCloudClientConfigService,
 	) {}
 
-	async onApplicationBootstrap(): Promise<void> {
-		await this.reconcileConfiguration();
+	onApplicationBootstrap(): void {
 		this.cleanupTimer = setInterval(() => {
 			void this.expireCandidates().catch(() => {
 				this.logger.warn('Homey Cloud pending grant cleanup is temporarily unavailable');
@@ -486,14 +485,6 @@ export class HomeyCloudGrantMutationService
 		);
 
 		if (result.affected !== 1) throw new HomeyCloudGrantStateError();
-	}
-
-	private async reconcileConfiguration(): Promise<void> {
-		await this.runMutation(() =>
-			this.dataSource.transaction(async (manager) => {
-				await this.reconcileConfigurationInternal(manager);
-			}),
-		);
 	}
 
 	private async reconcileConfigurationInternal(manager: EntityManager): Promise<HomeyCloudAuthorizationStateEntity> {

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-grant-mutation.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-grant-mutation.service.ts
@@ -1,0 +1,679 @@
+import { randomUUID } from 'node:crypto';
+import { DataSource, EntityManager, LessThanOrEqual } from 'typeorm';
+
+import { Injectable, Logger, OnApplicationBootstrap, OnModuleDestroy } from '@nestjs/common';
+
+import { UserEntity } from '../../../modules/users/entities/users.entity';
+import { UserLifecycleMutationParticipant } from '../../../modules/users/services/user-lifecycle-mutation-registry.service';
+import { UserRole } from '../../../modules/users/users.constants';
+import {
+	HOMEY_CLOUD_ACTIVE_GRANT_KEY,
+	HOMEY_CLOUD_AUTHORIZATION_STATE_KEY,
+	HOMEY_CLOUD_MAX_PENDING_AUTHORIZATIONS,
+	HOMEY_CLOUD_PENDING_GRANT_CLEANUP_INTERVAL_MS,
+	HOMEY_CLOUD_PENDING_GRANT_TTL_MS,
+} from '../devices-homey.constants';
+import {
+	HomeyCloudActiveGrantEntity,
+	HomeyCloudAuthorizationStateEntity,
+	HomeyCloudPendingGrantEntity,
+	HomeyCloudUserAuthorityEntity,
+} from '../entities/homey-cloud-grant.entity';
+import { HomeyCloudAuthorizationCapacityError } from '../errors/homey-cloud-authorization.error';
+import {
+	HomeyCloudGrantAuthorityError,
+	HomeyCloudGrantConflictError,
+	HomeyCloudGrantStateError,
+} from '../errors/homey-cloud-grant.error';
+
+const AUTHORIZED_ROLES = [UserRole.OWNER, UserRole.ADMIN];
+
+export interface HomeyCloudTokenMaterial {
+	readonly accessToken: string;
+	readonly expiresIn: number | null;
+	readonly grantType: string | null;
+	readonly issuedAt: number;
+	readonly refreshToken: string | null;
+	readonly tokenType: string;
+}
+
+export interface HomeyCloudAuthorizationContext {
+	readonly activeGrantGeneration: number;
+	readonly authorityGeneration: number;
+	readonly configurationGeneration: number;
+	readonly initiatingUserId: string;
+}
+
+export interface HomeyCloudCandidateInput extends HomeyCloudAuthorizationContext {
+	readonly expiresAt?: number;
+	readonly redirectUrl: string;
+	readonly token: HomeyCloudTokenMaterial;
+	readonly transactionId: string;
+}
+
+export interface HomeyCloudCandidateCredentials extends HomeyCloudCandidateInput {
+	readonly expiresAt: number;
+}
+
+export interface HomeyCloudActiveGrantReference {
+	readonly activatedById: string;
+	readonly authorityGeneration: number;
+	readonly configurationGeneration: number;
+	readonly generation: number;
+	readonly grantIdentifier: string;
+	readonly selectedHomeyId: string;
+}
+
+export interface HomeyCloudActiveGrantCredentials extends HomeyCloudActiveGrantReference {
+	readonly token: HomeyCloudTokenMaterial;
+}
+
+export interface HomeyCloudRefreshInput {
+	readonly configurationGeneration: number;
+	readonly generation: number;
+	readonly grantIdentifier: string;
+	readonly token: HomeyCloudTokenMaterial;
+}
+
+export type HomeyCloudMutationCommit<T> = (manager: EntityManager) => Promise<T>;
+
+type ActivationOutcome =
+	| { readonly status: 'activated'; readonly grant: HomeyCloudActiveGrantReference }
+	| { readonly status: 'authority' | 'conflict' };
+
+@Injectable()
+export class HomeyCloudGrantMutationService
+	implements OnApplicationBootstrap, OnModuleDestroy, UserLifecycleMutationParticipant
+{
+	private readonly logger = new Logger(HomeyCloudGrantMutationService.name);
+	private mutationTail: Promise<void> = Promise.resolve();
+	private cleanupTimer: NodeJS.Timeout | null = null;
+
+	constructor(private readonly dataSource: DataSource) {}
+
+	onApplicationBootstrap(): void {
+		this.cleanupTimer = setInterval(() => {
+			void this.expireCandidates().catch(() => {
+				this.logger.warn('Homey Cloud pending grant cleanup is temporarily unavailable');
+			});
+		}, HOMEY_CLOUD_PENDING_GRANT_CLEANUP_INTERVAL_MS);
+		this.cleanupTimer.unref();
+	}
+
+	onModuleDestroy(): void {
+		if (this.cleanupTimer) clearInterval(this.cleanupTimer);
+		this.cleanupTimer = null;
+	}
+
+	async getAuthorizationContext(initiatingUserId: string): Promise<HomeyCloudAuthorizationContext> {
+		this.assertIdentifier(initiatingUserId);
+
+		return this.runMutation(() =>
+			this.dataSource.transaction(async (manager) => {
+				await this.requireAuthorizedUser(manager, initiatingUserId);
+				const state = await this.getState(manager);
+				const authorityGeneration = await this.getOrCreateAuthorityGeneration(manager, initiatingUserId);
+
+				return {
+					activeGrantGeneration: state.activeGrantGeneration,
+					authorityGeneration,
+					configurationGeneration: state.configurationGeneration,
+					initiatingUserId,
+				};
+			}),
+		);
+	}
+
+	async stageCandidate(input: HomeyCloudCandidateInput): Promise<{ readonly expiresAt: number }> {
+		this.assertCandidate(input);
+		const now = Date.now();
+		const maximumExpiresAt = now + HOMEY_CLOUD_PENDING_GRANT_TTL_MS;
+		const expiresAt = input.expiresAt ?? maximumExpiresAt;
+
+		if (!Number.isSafeInteger(expiresAt) || expiresAt <= now || expiresAt > maximumExpiresAt) {
+			throw new HomeyCloudGrantConflictError();
+		}
+
+		return this.runMutation(() =>
+			this.dataSource.transaction(async (manager) => {
+				await this.deleteExpiredCandidates(manager, now);
+				await this.requireCurrentAuthority(manager, input.initiatingUserId, input.authorityGeneration);
+				const state = await this.getState(manager);
+
+				if (
+					state.activeGrantGeneration !== input.activeGrantGeneration ||
+					state.configurationGeneration !== input.configurationGeneration
+				) {
+					throw new HomeyCloudGrantConflictError();
+				}
+
+				const candidates = manager.getRepository(HomeyCloudPendingGrantEntity);
+
+				if (await candidates.existsBy({ transactionId: input.transactionId })) {
+					throw new HomeyCloudGrantConflictError();
+				}
+				if ((await candidates.count()) >= HOMEY_CLOUD_MAX_PENDING_AUTHORIZATIONS) {
+					throw new HomeyCloudAuthorizationCapacityError();
+				}
+
+				await candidates.insert({
+					transactionId: input.transactionId,
+					initiatingUserId: input.initiatingUserId,
+					authorityGeneration: input.authorityGeneration,
+					activeGrantGeneration: input.activeGrantGeneration,
+					configurationGeneration: input.configurationGeneration,
+					redirectUrl: input.redirectUrl,
+					tokenType: input.token.tokenType,
+					accessToken: input.token.accessToken,
+					refreshToken: input.token.refreshToken,
+					expiresIn: input.token.expiresIn,
+					grantType: input.token.grantType,
+					tokenIssuedAt: input.token.issuedAt,
+					expiresAt,
+				});
+
+				return { expiresAt };
+			}),
+		);
+	}
+
+	async loadCandidateCredentials(
+		transactionId: string,
+		initiatingUserId: string,
+	): Promise<HomeyCloudCandidateCredentials> {
+		this.assertIdentifier(transactionId);
+		this.assertIdentifier(initiatingUserId);
+
+		return this.runMutation(() =>
+			this.dataSource.transaction(async (manager) => {
+				const now = Date.now();
+				await this.deleteExpiredCandidates(manager, now);
+				const candidate = await this.findCandidateWithCredentials(manager, transactionId, initiatingUserId);
+
+				if (!candidate || candidate.expiresAt <= now) throw new HomeyCloudGrantConflictError();
+
+				return this.toCandidateCredentials(candidate);
+			}),
+		);
+	}
+
+	async cancelCandidate(transactionId: string, initiatingUserId: string): Promise<boolean> {
+		this.assertIdentifier(transactionId);
+		this.assertIdentifier(initiatingUserId);
+
+		return this.runMutation(async () => {
+			const result = await this.dataSource.getRepository(HomeyCloudPendingGrantEntity).delete({
+				transactionId,
+				initiatingUserId,
+			});
+
+			return result.affected === 1;
+		});
+	}
+
+	async expireCandidates(now = Date.now()): Promise<number> {
+		if (!Number.isSafeInteger(now) || now < 0) throw new TypeError('Homey Cloud cleanup time is invalid');
+
+		return this.runMutation(() => this.dataSource.transaction((manager) => this.deleteExpiredCandidates(manager, now)));
+	}
+
+	async activateCandidate(
+		transactionId: string,
+		initiatingUserId: string,
+		selectedHomeyId: string,
+	): Promise<HomeyCloudActiveGrantReference> {
+		this.assertIdentifier(transactionId);
+		this.assertIdentifier(initiatingUserId);
+		this.assertIdentifier(selectedHomeyId);
+
+		const outcome = await this.runMutation(() =>
+			this.dataSource.transaction((manager) =>
+				this.activateCandidateInternal(manager, transactionId, initiatingUserId, selectedHomeyId),
+			),
+		);
+
+		if (outcome.status !== 'activated') {
+			if (outcome.status === 'authority') throw new HomeyCloudGrantAuthorityError();
+			throw new HomeyCloudGrantConflictError();
+		}
+
+		return outcome.grant;
+	}
+
+	async loadActiveGrantCredentials(): Promise<HomeyCloudActiveGrantCredentials | null> {
+		return this.runMutation(async () => {
+			const active = await this.findActiveGrantWithCredentials(this.dataSource.manager);
+
+			return active ? this.toActiveCredentials(active) : null;
+		});
+	}
+
+	async persistRefresh(input: HomeyCloudRefreshInput): Promise<HomeyCloudActiveGrantReference | null> {
+		this.assertIdentifier(input.grantIdentifier);
+		this.assertGeneration(input.generation);
+		this.assertGeneration(input.configurationGeneration);
+		this.assertToken(input.token);
+
+		return this.runMutation(() =>
+			this.dataSource.transaction(async (manager) => {
+				const state = await this.getState(manager);
+
+				if (
+					state.activeGrantGeneration !== input.generation ||
+					state.configurationGeneration !== input.configurationGeneration
+				) {
+					return null;
+				}
+
+				const activeGrants = manager.getRepository(HomeyCloudActiveGrantEntity);
+				const active = await activeGrants.findOneBy({
+					key: HOMEY_CLOUD_ACTIVE_GRANT_KEY,
+					grantIdentifier: input.grantIdentifier,
+					generation: input.generation,
+					configurationGeneration: input.configurationGeneration,
+				});
+
+				if (!active) return null;
+
+				const nextGeneration = input.generation + 1;
+				const stateResult = await manager.getRepository(HomeyCloudAuthorizationStateEntity).update(
+					{
+						key: HOMEY_CLOUD_AUTHORIZATION_STATE_KEY,
+						activeGrantGeneration: input.generation,
+						configurationGeneration: input.configurationGeneration,
+					},
+					{ activeGrantGeneration: nextGeneration },
+				);
+
+				if (stateResult.affected !== 1) return null;
+
+				const grantResult = await activeGrants.update(
+					{
+						key: HOMEY_CLOUD_ACTIVE_GRANT_KEY,
+						grantIdentifier: input.grantIdentifier,
+						generation: input.generation,
+					},
+					{
+						generation: nextGeneration,
+						tokenType: input.token.tokenType,
+						accessToken: input.token.accessToken,
+						refreshToken: input.token.refreshToken,
+						expiresIn: input.token.expiresIn,
+						grantType: input.token.grantType,
+						tokenIssuedAt: input.token.issuedAt,
+						updatedAt: new Date(),
+					},
+				);
+
+				if (grantResult.affected !== 1) throw new HomeyCloudGrantStateError();
+
+				return this.toActiveReference({ ...active, generation: nextGeneration });
+			}),
+		);
+	}
+
+	async disconnect(actingUserId: string): Promise<boolean> {
+		this.assertIdentifier(actingUserId);
+
+		return this.runMutation(() =>
+			this.dataSource.transaction(async (manager) => {
+				await this.requireAuthorizedUser(manager, actingUserId);
+				const state = await this.getState(manager);
+				const result = await manager
+					.getRepository(HomeyCloudActiveGrantEntity)
+					.delete({ key: HOMEY_CLOUD_ACTIVE_GRANT_KEY });
+
+				await manager.getRepository(HomeyCloudPendingGrantEntity).clear();
+				await this.advanceState(manager, state, {
+					activeGrantGeneration: state.activeGrantGeneration + 1,
+				});
+
+				return result.affected === 1;
+			}),
+		);
+	}
+
+	async invalidateConfiguration<T>(commit: HomeyCloudMutationCommit<T>): Promise<T> {
+		return this.runMutation(() =>
+			this.dataSource.transaction(async (manager) => {
+				const state = await this.getState(manager);
+
+				await manager.getRepository(HomeyCloudPendingGrantEntity).clear();
+				await manager.getRepository(HomeyCloudActiveGrantEntity).clear();
+				await this.advanceState(manager, state, {
+					activeGrantGeneration: state.activeGrantGeneration + 1,
+					configurationGeneration: state.configurationGeneration + 1,
+				});
+
+				return commit(manager);
+			}),
+		);
+	}
+
+	async invalidateUserAuthority<T>(userId: string, commit: HomeyCloudMutationCommit<T>): Promise<T> {
+		this.assertIdentifier(userId);
+
+		return this.runMutation(() =>
+			this.dataSource.transaction(async (manager) => {
+				await this.invalidateUserAuthorityInternal(manager, userId);
+				return commit(manager);
+			}),
+		);
+	}
+
+	async prepareUpdate(previous: UserEntity, next: UserEntity, manager: EntityManager): Promise<void> {
+		const wasAuthorized = AUTHORIZED_ROLES.includes(previous.role);
+		const remainsAuthorized = AUTHORIZED_ROLES.includes(next.role);
+
+		if (wasAuthorized && !remainsAuthorized) {
+			await this.runMutation(() => this.invalidateUserAuthorityInternal(manager, next.id));
+		}
+	}
+
+	async prepareRemove(user: UserEntity, manager: EntityManager): Promise<void> {
+		await this.runMutation(() => this.invalidateUserAuthorityInternal(manager, user.id));
+	}
+
+	private async activateCandidateInternal(
+		manager: EntityManager,
+		transactionId: string,
+		initiatingUserId: string,
+		selectedHomeyId: string,
+	): Promise<ActivationOutcome> {
+		const now = Date.now();
+		await this.deleteExpiredCandidates(manager, now);
+		const candidate = await this.findCandidateWithCredentials(manager, transactionId, initiatingUserId);
+
+		if (!candidate) return { status: 'conflict' };
+
+		const user = await manager.getRepository(UserEntity).findOneBy({ id: initiatingUserId });
+		const authority = await manager.getRepository(HomeyCloudUserAuthorityEntity).findOneBy({
+			userId: initiatingUserId,
+		});
+		const authorityGeneration = authority?.generation ?? 0;
+		const state = await this.getState(manager);
+		const authorized = user !== null && AUTHORIZED_ROLES.includes(user.role);
+		const authorityCurrent = authorityGeneration === candidate.authorityGeneration;
+		const generationsCurrent =
+			state.activeGrantGeneration === candidate.activeGrantGeneration &&
+			state.configurationGeneration === candidate.configurationGeneration;
+
+		if (!authorized || !authorityCurrent || !generationsCurrent || candidate.expiresAt <= now) {
+			await manager.getRepository(HomeyCloudPendingGrantEntity).delete({ transactionId, initiatingUserId });
+
+			return { status: !authorized || !authorityCurrent ? 'authority' : 'conflict' };
+		}
+
+		const nextGeneration = state.activeGrantGeneration + 1;
+		const grantIdentifier = randomUUID();
+		const activeGrant = manager.getRepository(HomeyCloudActiveGrantEntity).create({
+			key: HOMEY_CLOUD_ACTIVE_GRANT_KEY,
+			grantIdentifier,
+			activatedById: initiatingUserId,
+			authorityGeneration,
+			generation: nextGeneration,
+			configurationGeneration: state.configurationGeneration,
+			selectedHomeyId,
+			tokenType: candidate.tokenType,
+			accessToken: candidate.accessToken,
+			refreshToken: candidate.refreshToken,
+			expiresIn: candidate.expiresIn,
+			grantType: candidate.grantType,
+			tokenIssuedAt: candidate.tokenIssuedAt,
+			activatedAt: new Date(),
+			updatedAt: null,
+		});
+
+		await manager.getRepository(HomeyCloudActiveGrantEntity).save(activeGrant);
+		const consumed = await manager.getRepository(HomeyCloudPendingGrantEntity).delete({
+			transactionId,
+			initiatingUserId,
+		});
+
+		if (consumed.affected !== 1) throw new HomeyCloudGrantStateError();
+
+		await this.advanceState(manager, state, { activeGrantGeneration: nextGeneration });
+
+		return { status: 'activated', grant: this.toActiveReference(activeGrant) };
+	}
+
+	private async getState(manager: EntityManager): Promise<HomeyCloudAuthorizationStateEntity> {
+		const states = manager.getRepository(HomeyCloudAuthorizationStateEntity);
+		let state = await states.findOneBy({ key: HOMEY_CLOUD_AUTHORIZATION_STATE_KEY });
+
+		if (!state) {
+			await states.insert({
+				key: HOMEY_CLOUD_AUTHORIZATION_STATE_KEY,
+				activeGrantGeneration: 0,
+				configurationGeneration: 0,
+			});
+			state = await states.findOneBy({ key: HOMEY_CLOUD_AUTHORIZATION_STATE_KEY });
+		}
+
+		if (!state) throw new HomeyCloudGrantStateError();
+
+		return state;
+	}
+
+	private async advanceState(
+		manager: EntityManager,
+		state: HomeyCloudAuthorizationStateEntity,
+		update: Partial<Pick<HomeyCloudAuthorizationStateEntity, 'activeGrantGeneration' | 'configurationGeneration'>>,
+	): Promise<void> {
+		const result = await manager.getRepository(HomeyCloudAuthorizationStateEntity).update(
+			{
+				key: HOMEY_CLOUD_AUTHORIZATION_STATE_KEY,
+				activeGrantGeneration: state.activeGrantGeneration,
+				configurationGeneration: state.configurationGeneration,
+			},
+			update,
+		);
+
+		if (result.affected !== 1) throw new HomeyCloudGrantStateError();
+	}
+
+	private async requireCurrentAuthority(
+		manager: EntityManager,
+		userId: string,
+		expectedGeneration: number,
+	): Promise<void> {
+		await this.requireAuthorizedUser(manager, userId);
+		const actualGeneration = await this.getOrCreateAuthorityGeneration(manager, userId);
+
+		if (actualGeneration !== expectedGeneration) throw new HomeyCloudGrantAuthorityError();
+	}
+
+	private async requireAuthorizedUser(manager: EntityManager, userId: string): Promise<UserEntity> {
+		const user = await manager.getRepository(UserEntity).findOneBy({ id: userId });
+
+		if (!user || !AUTHORIZED_ROLES.includes(user.role)) throw new HomeyCloudGrantAuthorityError();
+
+		return user;
+	}
+
+	private async getOrCreateAuthorityGeneration(manager: EntityManager, userId: string): Promise<number> {
+		const authorities = manager.getRepository(HomeyCloudUserAuthorityEntity);
+		let authority = await authorities.findOneBy({ userId });
+
+		if (!authority) {
+			await authorities.insert({ userId, generation: 0 });
+			authority = await authorities.findOneBy({ userId });
+		}
+
+		if (!authority) throw new HomeyCloudGrantStateError();
+
+		return authority.generation;
+	}
+
+	private async advanceAuthority(manager: EntityManager, userId: string): Promise<void> {
+		const authorities = manager.getRepository(HomeyCloudUserAuthorityEntity);
+		const authority = await authorities.findOneBy({ userId });
+
+		if (!authority) {
+			await authorities.insert({ userId, generation: 1 });
+			return;
+		}
+
+		const result = await authorities.update(
+			{ userId, generation: authority.generation },
+			{ generation: authority.generation + 1 },
+		);
+
+		if (result.affected !== 1) throw new HomeyCloudGrantStateError();
+	}
+
+	private async invalidateUserAuthorityInternal(manager: EntityManager, userId: string): Promise<void> {
+		await this.advanceAuthority(manager, userId);
+		await manager.getRepository(HomeyCloudPendingGrantEntity).delete({ initiatingUserId: userId });
+
+		const activeGrants = manager.getRepository(HomeyCloudActiveGrantEntity);
+		const active = await activeGrants.findOneBy({
+			key: HOMEY_CLOUD_ACTIVE_GRANT_KEY,
+			activatedById: userId,
+		});
+
+		if (!active) return;
+
+		const state = await this.getState(manager);
+		await activeGrants.delete({ key: HOMEY_CLOUD_ACTIVE_GRANT_KEY });
+		await this.advanceState(manager, state, {
+			activeGrantGeneration: state.activeGrantGeneration + 1,
+		});
+	}
+
+	private async deleteExpiredCandidates(manager: EntityManager, now: number): Promise<number> {
+		const result = await manager.getRepository(HomeyCloudPendingGrantEntity).delete({
+			expiresAt: LessThanOrEqual(now),
+		});
+
+		return result.affected ?? 0;
+	}
+
+	private findCandidateWithCredentials(
+		manager: EntityManager,
+		transactionId: string,
+		initiatingUserId: string,
+	): Promise<HomeyCloudPendingGrantEntity | null> {
+		return manager
+			.getRepository(HomeyCloudPendingGrantEntity)
+			.createQueryBuilder('candidate')
+			.addSelect([
+				'candidate.tokenType',
+				'candidate.accessToken',
+				'candidate.refreshToken',
+				'candidate.expiresIn',
+				'candidate.grantType',
+				'candidate.tokenIssuedAt',
+			])
+			.where('candidate.transactionId = :transactionId', { transactionId })
+			.andWhere('candidate.initiatingUserId = :initiatingUserId', { initiatingUserId })
+			.getOne();
+	}
+
+	private findActiveGrantWithCredentials(manager: EntityManager): Promise<HomeyCloudActiveGrantEntity | null> {
+		return manager
+			.getRepository(HomeyCloudActiveGrantEntity)
+			.createQueryBuilder('grant')
+			.addSelect([
+				'grant.tokenType',
+				'grant.accessToken',
+				'grant.refreshToken',
+				'grant.expiresIn',
+				'grant.grantType',
+				'grant.tokenIssuedAt',
+			])
+			.where('grant.key = :key', { key: HOMEY_CLOUD_ACTIVE_GRANT_KEY })
+			.getOne();
+	}
+
+	private toCandidateCredentials(candidate: HomeyCloudPendingGrantEntity): HomeyCloudCandidateCredentials {
+		return {
+			transactionId: candidate.transactionId,
+			initiatingUserId: candidate.initiatingUserId,
+			authorityGeneration: candidate.authorityGeneration,
+			activeGrantGeneration: candidate.activeGrantGeneration,
+			configurationGeneration: candidate.configurationGeneration,
+			redirectUrl: candidate.redirectUrl,
+			expiresAt: candidate.expiresAt,
+			token: this.toTokenMaterial(candidate),
+		};
+	}
+
+	private toActiveCredentials(active: HomeyCloudActiveGrantEntity): HomeyCloudActiveGrantCredentials {
+		return { ...this.toActiveReference(active), token: this.toTokenMaterial(active) };
+	}
+
+	private toActiveReference(active: HomeyCloudActiveGrantEntity): HomeyCloudActiveGrantReference {
+		return {
+			grantIdentifier: active.grantIdentifier,
+			activatedById: active.activatedById,
+			authorityGeneration: active.authorityGeneration,
+			generation: active.generation,
+			configurationGeneration: active.configurationGeneration,
+			selectedHomeyId: active.selectedHomeyId,
+		};
+	}
+
+	private toTokenMaterial(grant: HomeyCloudPendingGrantEntity | HomeyCloudActiveGrantEntity): HomeyCloudTokenMaterial {
+		return {
+			tokenType: grant.tokenType,
+			accessToken: grant.accessToken,
+			refreshToken: grant.refreshToken,
+			expiresIn: grant.expiresIn,
+			grantType: grant.grantType,
+			issuedAt: grant.tokenIssuedAt,
+		};
+	}
+
+	private assertCandidate(input: HomeyCloudCandidateInput): void {
+		this.assertIdentifier(input.transactionId);
+		this.assertIdentifier(input.initiatingUserId);
+		this.assertIdentifier(input.redirectUrl);
+		this.assertGeneration(input.authorityGeneration);
+		this.assertGeneration(input.activeGrantGeneration);
+		this.assertGeneration(input.configurationGeneration);
+		this.assertToken(input.token);
+	}
+
+	private assertToken(token: HomeyCloudTokenMaterial): void {
+		this.assertIdentifier(token.tokenType);
+		this.assertIdentifier(token.accessToken);
+
+		if (token.refreshToken !== null) this.assertIdentifier(token.refreshToken);
+		if (token.grantType !== null) this.assertIdentifier(token.grantType);
+		if (token.expiresIn !== null && (!Number.isSafeInteger(token.expiresIn) || token.expiresIn < 0)) {
+			throw new TypeError('Homey Cloud token material is invalid');
+		}
+		if (!Number.isSafeInteger(token.issuedAt) || token.issuedAt < 0) {
+			throw new TypeError('Homey Cloud token material is invalid');
+		}
+	}
+
+	private assertIdentifier(value: string): void {
+		if (typeof value !== 'string' || value.trim().length === 0) {
+			throw new TypeError('Homey Cloud authorization identifier is invalid');
+		}
+	}
+
+	private assertGeneration(value: number): void {
+		if (!Number.isSafeInteger(value) || value < 0) {
+			throw new TypeError('Homey Cloud authorization generation is invalid');
+		}
+	}
+
+	private async runMutation<T>(operation: () => Promise<T>): Promise<T> {
+		const previousMutation = this.mutationTail;
+		let releaseMutation = (): void => undefined;
+		this.mutationTail = new Promise<void>((resolve) => {
+			releaseMutation = resolve;
+		});
+
+		await previousMutation;
+
+		try {
+			return await operation();
+		} finally {
+			releaseMutation();
+		}
+	}
+}

--- a/docs/homey-cloud-oauth.md
+++ b/docs/homey-cloud-oauth.md
@@ -159,6 +159,21 @@ The implementation that follows this record must:
     same serialized mutation boundary, then invalidate and clear tokens plus the selected Homey and disconnect the
     Homey connector before reporting OAuth disconnect success.
 
+### Grant persistence boundary
+
+Task 7.2b adds provider-scoped pending-candidate, active-grant, user-authority, and generation-state tables through the
+incremental `1000000000025-AddHomeyCloudGrants` migration. OAuth token fields are excluded from ordinary TypeORM reads;
+only explicit backend credential-loading methods select them, and no controller or browser DTO exposes those methods.
+The pending table is transaction- and initiating-user-scoped, has a server-capped absolute lifetime and capacity, and is
+swept independently of requests.
+
+One serialized mutation service owns candidate staging, cancellation, expiry and activation plus active-grant refresh,
+disconnect and configuration invalidation. Activation and refresh use generation and grant-identity compare-and-swap
+checks so a late provider result cannot revive cleared credentials or overwrite a replacement. Administrator demotion
+and removal participate in the same user database transaction through the additive user-lifecycle mutation boundary;
+this advances the user's authority generation and clears credentials authorized by that user before the account change
+commits. Provider exchange, Homey selection and HTTP routes remain intentionally absent until Tasks 7.2c and 7.2d.
+
 The current official client and HTTP references do not document a standards-style token-revocation endpoint. Task 7.2
 must verify the current live/API behavior before claiming remote revocation. Until then, disconnect means local token
 deletion and connector teardown, while the operator can revoke the grant from Homey account controls.

--- a/docs/homey-cloud-oauth.md
+++ b/docs/homey-cloud-oauth.md
@@ -167,6 +167,11 @@ only explicit backend credential-loading methods select them, and no controller 
 The pending table is transaction- and initiating-user-scoped, has a server-capped absolute lifetime and capacity, and is
 swept independently of requests.
 
+The state table also stores a SHA-256 identity derived from the deployment client ID, client secret, exact redirect URL,
+and requested scopes. Startup and every backend credential load compare the current non-secret fingerprint with the
+persisted value. A change clears pending and active grants and advances both generations before stale credentials can be
+used; the client secret itself is never persisted in the state table.
+
 One serialized mutation service owns candidate staging, cancellation, expiry and activation plus active-grant refresh,
 disconnect and configuration invalidation. Activation and refresh use generation and grant-identity compare-and-swap
 checks so a late provider result cannot revive cleared credentials or overwrite a replacement. Administrator demotion

--- a/docs/homey-cloud-oauth.md
+++ b/docs/homey-cloud-oauth.md
@@ -168,9 +168,9 @@ The pending table is transaction- and initiating-user-scoped, has a server-cappe
 swept independently of requests.
 
 The state table also stores a SHA-256 identity derived from the deployment client ID, client secret, exact redirect URL,
-and requested scopes. Startup and every backend credential load compare the current non-secret fingerprint with the
-persisted value. A change clears pending and active grants and advances both generations before stale credentials can be
-used; the client secret itself is never persisted in the state table.
+and requested scopes. Every authorization-context, credential-loading, activation, refresh and disconnect path compares
+the current non-secret fingerprint with the persisted value. A change clears pending and active grants and advances both
+generations before stale credentials can be used; the client secret itself is never persisted in the state table.
 
 One serialized mutation service owns candidate staging, cancellation, expiry and activation plus active-grant refresh,
 disconnect and configuration invalidation. Activation and refresh use generation and grant-identity compare-and-swap

--- a/docs/homey-cloud-oauth.md
+++ b/docs/homey-cloud-oauth.md
@@ -177,7 +177,9 @@ disconnect and configuration invalidation. Activation and refresh use generation
 checks so a late provider result cannot revive cleared credentials or overwrite a replacement. Administrator demotion
 and removal participate in the same user database transaction through the additive user-lifecycle mutation boundary;
 this advances the user's authority generation and clears credentials authorized by that user before the account change
-commits. Provider exchange, Homey selection and HTTP routes remain intentionally absent until Tasks 7.2c and 7.2d.
+commits. The provider factory-reset handler clears pending grants, active credentials and user-authority metadata before
+the core device and user reset handlers run, while advancing both persisted generations. Provider exchange, Homey
+selection and HTTP routes remain intentionally absent until Tasks 7.2c and 7.2d.
 
 The current official client and HTTP references do not document a standards-style token-revocation endpoint. Task 7.2
 must verify the current live/API behavior before claiming remote revocation. Until then, disconnect means local token

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -848,7 +848,7 @@ Task 7.2 is delivered behind disabled cloud mode in reviewable slices:
       generate the SDK authorization URL with candidate auto-refresh disabled; keep only a hash of bounded, single-use
       state; bind it to the initiating user plus authority/active-grant generations; and expire it independently of
       follow-up traffic. No cloud route is exposed by this slice.
-- [ ] **7.2b — Grant persistence and mutation gate:** add incremental storage for pending/active grant metadata and
+- [x] **7.2b — Grant persistence and mutation gate:** add incremental storage for pending/active grant metadata and
       write-only token material, then serialize activation, cancellation, expiry, refresh, disconnect, configuration,
       and user-authority invalidation.
 - [ ] **7.2c — Provider exchange and Homey selection:** exchange the code with a bounded timeout, stage candidate tokens,


### PR DESCRIPTION
## Summary

- add incremental Homey Cloud authorization state, user-authority, pending-candidate, and active-grant storage
- keep OAuth token material out of ordinary ORM reads and expose it only through explicit backend credential methods
- serialize staging, activation, cancellation, expiry, refresh rotation, disconnect, configuration invalidation, and user-authority invalidation
- join Homey authority revocation to the existing user lifecycle transaction without replacing the MCP lifecycle orchestrator
- bind OAuth state to configuration generation and document completion of Task 7.2b
- persist a non-secret OAuth configuration fingerprint and invalidate stale grants before authorization or credential use
- clear all Homey Cloud credentials and authority metadata through the system factory-reset registry

## Safety and race handling

- activation rechecks current owner/admin authority plus authority, active-grant, and configuration generations
- refresh persistence uses grant identity and generation compare-and-swap so late responses cannot restore stale credentials
- candidate expiry is absolute, server-capped, capacity-bounded, and swept independently of request traffic
- failed configuration or user mutations roll back credential invalidation atomically
- client ID, secret, redirect URL, or scope changes invalidate persisted credentials before use
- factory reset clears credentials before core device and user records and advances both generations
- no Homey Cloud HTTP route is exposed in this slice

## Verification

- backend type-check
- backend build
- OpenAPI generation
- focused ESLint for changed user lifecycle and Homey sources
- 44 Homey, user-lifecycle, user-service, and migration test suites / 515 tests