### PR TITLE
feat(backend): add Homey Cloud provider authorization

### DIFF
--- a/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.spec.ts
@@ -391,6 +391,40 @@ describe('HomeySdkClientFactoryService', () => {
 		expect(remainingHomey.authenticate).not.toHaveBeenCalled();
 	});
 
+	it('rejects duplicate eligible identifiers in the final inventory', async () => {
+		const firstHomey = {
+			id: 'homey-one',
+			name: 'Home',
+			apiVersion: 3,
+			platform: 'local',
+			remoteUrl: 'https://homey-one.connect.athom.com',
+			authenticate: jest.fn(),
+		};
+		const secondHomey = { ...firstHomey, name: 'Duplicate Home' };
+
+		jest.spyOn(AthomCloudAPI.prototype, 'getAuthenticatedUser').mockResolvedValue({
+			getHomeys: () => [firstHomey, secondHomey],
+			getHomeyById: () => firstHomey,
+		} as unknown as AthomCloudAPI.User);
+		const provider = new HomeySdkClientFactoryService().createCloudProviderClient({
+			clientId: 'deployment-client-id',
+			clientSecret: 'deployment-client-secret',
+			redirectUrl: `https://panel.example.com${HOMEY_CLOUD_CALLBACK_PATH}`,
+			token: {
+				tokenType: 'bearer',
+				accessToken: 'candidate-access-token',
+				refreshToken: 'candidate-refresh-token',
+				expiresIn: 3600,
+				grantType: 'authorization_code',
+			},
+		});
+
+		await expect(provider.authenticateHomey('homey-one', new AbortController().signal, false)).rejects.toMatchObject({
+			name: 'HomeyCloudSdkProtocolError',
+		});
+		expect(firstHomey.authenticate).not.toHaveBeenCalled();
+	});
+
 	it('preserves retryable HTTP status from child Homey SDK requests', async () => {
 		const server = createServer((_request, response) => {
 			response.writeHead(429, { 'Content-Type': 'text/plain' });

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.spec.ts
@@ -117,7 +117,10 @@ describe('HomeySdkClientFactoryService', () => {
 	});
 
 	it('classifies token HTTP failures before attempting to parse their body', async () => {
-		jest.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('not-json', { status: 429 }));
+		const response = new Response('not-json', { status: 429 });
+		const cancelBody = jest.spyOn(response.body as ReadableStream, 'cancel');
+
+		jest.spyOn(globalThis, 'fetch').mockResolvedValue(response);
 		const provider = new HomeySdkClientFactoryService().createCloudProviderClient({
 			clientId: 'deployment-client-id',
 			clientSecret: 'deployment-client-secret',
@@ -129,6 +132,7 @@ describe('HomeySdkClientFactoryService', () => {
 		).rejects.toMatchObject({
 			statusCode: 429,
 		});
+		expect(cancelBody).toHaveBeenCalledTimes(1);
 	});
 
 	it('keeps cancellation attached while the SDK consumes an account response body', async () => {

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.spec.ts
@@ -190,6 +190,33 @@ describe('HomeySdkClientFactoryService', () => {
 		expect(bodyAborted).toBe(true);
 	});
 
+	it('preserves timeout classification while consuming a token response body', async () => {
+		const timeoutController = new AbortController();
+
+		jest.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutController.signal);
+		jest.spyOn(globalThis, 'fetch').mockImplementation((_input, init) => {
+			const body = new ReadableStream({
+				start(controller) {
+					init?.signal?.addEventListener('abort', () => controller.error(new DOMException('Aborted', 'AbortError')), {
+						once: true,
+					});
+				},
+			});
+
+			return Promise.resolve(new Response(body, { headers: { 'Content-Type': 'application/json' } }));
+		});
+		const provider = new HomeySdkClientFactoryService().createCloudProviderClient({
+			clientId: 'deployment-client-id',
+			clientSecret: 'deployment-client-secret',
+			redirectUrl: `https://panel.example.com${HOMEY_CLOUD_CALLBACK_PATH}`,
+		});
+		const exchange = provider.exchangeAuthorizationCode('authorization-code', new AbortController().signal);
+
+		timeoutController.abort();
+
+		await expect(exchange).rejects.toMatchObject({ statusCode: 408 });
+	});
+
 	it('rejects an untrusted child Homey cloud endpoint before authentication', async () => {
 		const homey = {
 			id: 'homey-one',

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.spec.ts
@@ -1,3 +1,5 @@
+import { AthomCloudAPI } from 'homey-api';
+
 import { HOMEY_CLOUD_CALLBACK_PATH, HOMEY_CLOUD_SCOPES } from '../devices-homey.constants';
 import { HomeyCloudConfigurationError } from '../errors/homey-cloud-authorization.error';
 
@@ -7,11 +9,72 @@ describe('HomeySdkClientFactoryService', () => {
 	const originalBaseUrl = process.env.ATHOM_CLOUD_API_BASEURL;
 
 	afterEach(() => {
+		jest.restoreAllMocks();
+
 		if (originalBaseUrl === undefined) {
 			delete process.env.ATHOM_CLOUD_API_BASEURL;
 		} else {
 			process.env.ATHOM_CLOUD_API_BASEURL = originalBaseUrl;
 		}
+	});
+
+	it('creates isolated provider clients for exchange and sanitized Homey access', async () => {
+		const token = {
+			token_type: 'bearer',
+			access_token: 'provider-access-token',
+			refresh_token: 'provider-refresh-token',
+			expires_in: 3600,
+			grant_type: 'authorization_code',
+		};
+		const authenticateWithAuthorizationCode = jest
+			.spyOn(AthomCloudAPI.prototype, 'authenticateWithAuthorizationCode')
+			.mockResolvedValue(token as unknown as AthomCloudAPI.Token);
+		const homeyApi = {
+			disconnect: jest.fn().mockResolvedValue(undefined),
+			destroy: jest.fn(),
+		};
+		const homey = {
+			id: 'homey-one',
+			name: 'Home',
+			apiVersion: 3,
+			platform: 'local',
+			authenticate: jest.fn().mockResolvedValue(homeyApi),
+		};
+		jest.spyOn(AthomCloudAPI.prototype, 'getAuthenticatedUser').mockResolvedValue({
+			getHomeys: () => [homey],
+			getHomeyById: () => homey,
+		} as unknown as AthomCloudAPI.User);
+		const factory = new HomeySdkClientFactoryService();
+		const provider = factory.createCloudProviderClient({
+			clientId: 'deployment-client-id',
+			clientSecret: 'deployment-client-secret',
+			redirectUrl: `https://panel.example.com${HOMEY_CLOUD_CALLBACK_PATH}`,
+		});
+		const candidateProvider = factory.createCloudProviderClient({
+			clientId: 'deployment-client-id',
+			clientSecret: 'deployment-client-secret',
+			redirectUrl: `https://panel.example.com${HOMEY_CLOUD_CALLBACK_PATH}`,
+			token: {
+				tokenType: 'bearer',
+				accessToken: token.access_token,
+				refreshToken: token.refresh_token,
+				expiresIn: token.expires_in,
+				grantType: token.grant_type,
+			},
+		});
+
+		await expect(provider.exchangeAuthorizationCode('authorization-code')).resolves.toBe(token);
+		await expect(candidateProvider.getHomeys()).resolves.toEqual([
+			{ id: 'homey-one', name: 'Home', apiVersion: 3, platform: 'local' },
+		]);
+		await expect(candidateProvider.authenticateHomey('homey-one')).resolves.toBeUndefined();
+		expect(authenticateWithAuthorizationCode).toHaveBeenCalledWith({
+			code: 'authorization-code',
+			removeCodeFromHistory: false,
+		});
+		expect(homey.authenticate).toHaveBeenCalledWith({ strategy: 'cloud', reconnect: false });
+		expect(homeyApi.disconnect).toHaveBeenCalledTimes(1);
+		expect(homeyApi.destroy).toHaveBeenCalledTimes(1);
 	});
 
 	it('creates a Homey Cloud authorization URL without exposing the client secret', () => {

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.spec.ts
@@ -1,4 +1,7 @@
 import { AthomCloudAPI } from 'homey-api';
+import { once } from 'node:events';
+import { createServer } from 'node:http';
+import { createRequire } from 'node:module';
 
 import { HOMEY_CLOUD_CALLBACK_PATH, HOMEY_CLOUD_SCOPES } from '../devices-homey.constants';
 import { HomeyCloudConfigurationError } from '../errors/homey-cloud-authorization.error';
@@ -110,6 +113,71 @@ describe('HomeySdkClientFactoryService', () => {
 
 		await expect(exchange).rejects.toMatchObject({ code: 'ABORTERROR' });
 		expect(requestSignal?.aborted).toBe(true);
+	});
+
+	it('propagates cancellation into the child Homey login requests', async () => {
+		let requestStartedResolve: (() => void) | null = null;
+		const requestStarted = new Promise<void>((resolve) => {
+			requestStartedResolve = resolve;
+		});
+		const server = createServer(() => requestStartedResolve?.());
+
+		server.listen(0, '127.0.0.1');
+		await once(server, 'listening');
+
+		try {
+			const address = server.address();
+
+			if (address === null || typeof address === 'string') throw new Error('Test server address is unavailable');
+
+			const sdkUtility = (
+				createRequire(__filename)('homey-api') as {
+					Util: {
+						fetch(url: string, options: RequestInit, timeoutDuration: number): Promise<Response>;
+					};
+				}
+			).Util;
+			const homey = {
+				id: 'homey-one',
+				name: 'Home',
+				apiVersion: 3,
+				platform: 'local',
+				authenticate: jest.fn(async () => {
+					await sdkUtility.fetch(`http://127.0.0.1:${address.port}/login`, {}, 60_000);
+
+					throw new Error('The stalled test request unexpectedly completed');
+				}),
+			};
+
+			jest.spyOn(AthomCloudAPI.prototype, 'getAuthenticatedUser').mockResolvedValue({
+				getHomeys: () => [homey],
+				getHomeyById: () => homey,
+			} as unknown as AthomCloudAPI.User);
+			const provider = new HomeySdkClientFactoryService().createCloudProviderClient({
+				clientId: 'deployment-client-id',
+				clientSecret: 'deployment-client-secret',
+				redirectUrl: `https://panel.example.com${HOMEY_CLOUD_CALLBACK_PATH}`,
+				token: {
+					tokenType: 'bearer',
+					accessToken: 'candidate-access-token',
+					refreshToken: 'candidate-refresh-token',
+					expiresIn: 3600,
+					grantType: 'authorization_code',
+				},
+			});
+			const controller = new AbortController();
+			const authentication = provider.authenticateHomey('homey-one', controller.signal);
+
+			await requestStarted;
+			controller.abort();
+
+			await expect(authentication).rejects.toMatchObject({ code: 'ABORTERROR' });
+		} finally {
+			server.closeAllConnections();
+			await new Promise<void>((resolve, reject) => {
+				server.close((error) => (error ? reject(error) : resolve()));
+			});
+		}
 	});
 
 	it('creates a Homey Cloud authorization URL without exposing the client secret', () => {

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.spec.ts
@@ -319,6 +319,78 @@ describe('HomeySdkClientFactoryService', () => {
 		expect(homey.authenticate.mock.calls).toHaveLength(0);
 	});
 
+	it('counts only eligible Homeys when revalidating automatic authentication', async () => {
+		const homeyApi = {
+			disconnect: jest.fn().mockResolvedValue(undefined),
+			destroy: jest.fn(),
+		};
+		const homey = {
+			id: 'homey-one',
+			name: 'Home',
+			apiVersion: 3,
+			platform: 'local',
+			remoteUrl: 'https://homey-one.connect.athom.com',
+			authenticate: jest.fn().mockResolvedValue(homeyApi),
+		};
+
+		jest.spyOn(AthomCloudAPI.prototype, 'getAuthenticatedUser').mockResolvedValue({
+			getHomeys: () => [homey, { ...homey, id: 'future-homey', apiVersion: 4 }],
+			getHomeyById: () => homey,
+		} as unknown as AthomCloudAPI.User);
+		const provider = new HomeySdkClientFactoryService().createCloudProviderClient({
+			clientId: 'deployment-client-id',
+			clientSecret: 'deployment-client-secret',
+			redirectUrl: `https://panel.example.com${HOMEY_CLOUD_CALLBACK_PATH}`,
+			token: {
+				tokenType: 'bearer',
+				accessToken: 'candidate-access-token',
+				refreshToken: 'candidate-refresh-token',
+				expiresIn: 3600,
+				grantType: 'authorization_code',
+			},
+		});
+
+		await expect(provider.authenticateHomey('homey-one', new AbortController().signal, true)).resolves.toBeUndefined();
+		expect(homey.authenticate).toHaveBeenCalledWith({ strategy: 'cloud', reconnect: false });
+	});
+
+	it('rejects a selection that disappears from the final inventory without querying it by id', async () => {
+		const remainingHomey = {
+			id: 'homey-two',
+			name: 'Other Homey',
+			apiVersion: 3,
+			platform: 'local',
+			remoteUrl: 'https://homey-two.connect.athom.com',
+			authenticate: jest.fn(),
+		};
+		const getHomeyById = jest.fn(() => {
+			throw Object.assign(new Error('not found'), { statusCode: 404 });
+		});
+
+		jest.spyOn(AthomCloudAPI.prototype, 'getAuthenticatedUser').mockResolvedValue({
+			getHomeys: () => [remainingHomey],
+			getHomeyById,
+		} as unknown as AthomCloudAPI.User);
+		const provider = new HomeySdkClientFactoryService().createCloudProviderClient({
+			clientId: 'deployment-client-id',
+			clientSecret: 'deployment-client-secret',
+			redirectUrl: `https://panel.example.com${HOMEY_CLOUD_CALLBACK_PATH}`,
+			token: {
+				tokenType: 'bearer',
+				accessToken: 'candidate-access-token',
+				refreshToken: 'candidate-refresh-token',
+				expiresIn: 3600,
+				grantType: 'authorization_code',
+			},
+		});
+
+		await expect(provider.authenticateHomey('homey-one', new AbortController().signal, false)).rejects.toThrow(
+			HomeyCloudSelectionError,
+		);
+		expect(getHomeyById).not.toHaveBeenCalled();
+		expect(remainingHomey.authenticate).not.toHaveBeenCalled();
+	});
+
 	it('preserves retryable HTTP status from child Homey SDK requests', async () => {
 		const server = createServer((_request, response) => {
 			response.writeHead(429, { 'Content-Type': 'text/plain' });

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.spec.ts
@@ -4,7 +4,7 @@ import { createServer } from 'node:http';
 import { createRequire } from 'node:module';
 
 import { HOMEY_CLOUD_CALLBACK_PATH, HOMEY_CLOUD_SCOPES } from '../devices-homey.constants';
-import { HomeyCloudConfigurationError } from '../errors/homey-cloud-authorization.error';
+import { HomeyCloudConfigurationError, HomeyCloudSelectionError } from '../errors/homey-cloud-authorization.error';
 
 import { HomeySdkClientFactoryService } from './homey-sdk.client';
 
@@ -75,7 +75,7 @@ describe('HomeySdkClientFactoryService', () => {
 		await expect(candidateProvider.getHomeys(controller.signal)).resolves.toEqual([
 			{ id: 'homey-one', name: 'Home', apiVersion: 3, platform: 'local' },
 		]);
-		await expect(candidateProvider.authenticateHomey('homey-one', controller.signal)).resolves.toBeUndefined();
+		await expect(candidateProvider.authenticateHomey('homey-one', controller.signal, false)).resolves.toBeUndefined();
 		const [tokenUrl, tokenRequest] = fetchMock.mock.calls[0];
 
 		expect(tokenUrl).toBe('https://api.athom.com/oauth2/token');
@@ -248,7 +248,7 @@ describe('HomeySdkClientFactoryService', () => {
 			},
 		});
 
-		await expect(provider.authenticateHomey('homey-one', new AbortController().signal)).rejects.toMatchObject({
+		await expect(provider.authenticateHomey('homey-one', new AbortController().signal, false)).rejects.toMatchObject({
 			name: 'HomeyCloudSdkProtocolError',
 		});
 		expect(homey.authenticate.mock.calls).toHaveLength(0);
@@ -280,8 +280,43 @@ describe('HomeySdkClientFactoryService', () => {
 			},
 		});
 
-		await expect(provider.authenticateHomey('legacy-homey', new AbortController().signal)).resolves.toBeUndefined();
+		await expect(
+			provider.authenticateHomey('legacy-homey', new AbortController().signal, false),
+		).resolves.toBeUndefined();
 		expect(homey.authenticate).toHaveBeenCalledWith({ strategy: 'cloud', reconnect: false });
+	});
+
+	it('rejects automatic authentication when the final inventory is no longer a singleton', async () => {
+		const homey = {
+			id: 'homey-one',
+			name: 'Home',
+			apiVersion: 3,
+			platform: 'local',
+			remoteUrl: 'https://homey-one.connect.athom.com',
+			authenticate: jest.fn(),
+		};
+
+		jest.spyOn(AthomCloudAPI.prototype, 'getAuthenticatedUser').mockResolvedValue({
+			getHomeys: () => [homey, { ...homey, id: 'homey-two', name: 'Other Homey' }],
+			getHomeyById: () => homey,
+		} as unknown as AthomCloudAPI.User);
+		const provider = new HomeySdkClientFactoryService().createCloudProviderClient({
+			clientId: 'deployment-client-id',
+			clientSecret: 'deployment-client-secret',
+			redirectUrl: `https://panel.example.com${HOMEY_CLOUD_CALLBACK_PATH}`,
+			token: {
+				tokenType: 'bearer',
+				accessToken: 'candidate-access-token',
+				refreshToken: 'candidate-refresh-token',
+				expiresIn: 3600,
+				grantType: 'authorization_code',
+			},
+		});
+
+		await expect(provider.authenticateHomey('homey-one', new AbortController().signal, true)).rejects.toThrow(
+			HomeyCloudSelectionError,
+		);
+		expect(homey.authenticate.mock.calls).toHaveLength(0);
 	});
 
 	it('preserves retryable HTTP status from child Homey SDK requests', async () => {
@@ -331,7 +366,7 @@ describe('HomeySdkClientFactoryService', () => {
 				},
 			});
 
-			await expect(provider.authenticateHomey('homey-one', new AbortController().signal)).rejects.toMatchObject({
+			await expect(provider.authenticateHomey('homey-one', new AbortController().signal, false)).rejects.toMatchObject({
 				statusCode: 429,
 			});
 		} finally {
@@ -394,7 +429,7 @@ describe('HomeySdkClientFactoryService', () => {
 				},
 			});
 			const controller = new AbortController();
-			const authentication = provider.authenticateHomey('homey-one', controller.signal);
+			const authentication = provider.authenticateHomey('homey-one', controller.signal, false);
 
 			await requestStarted;
 			controller.abort();

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.spec.ts
@@ -43,6 +43,7 @@ describe('HomeySdkClientFactoryService', () => {
 			name: 'Home',
 			apiVersion: 3,
 			platform: 'local',
+			remoteUrl: 'https://homey-one.connect.athom.com',
 			authenticate: jest.fn().mockResolvedValue(homeyApi),
 		};
 		jest.spyOn(AthomCloudAPI.prototype, 'getAuthenticatedUser').mockResolvedValue({
@@ -189,6 +190,39 @@ describe('HomeySdkClientFactoryService', () => {
 		expect(bodyAborted).toBe(true);
 	});
 
+	it('rejects an untrusted child Homey cloud endpoint before authentication', async () => {
+		const homey = {
+			id: 'homey-one',
+			name: 'Home',
+			apiVersion: 3,
+			platform: 'local',
+			remoteUrl: 'http://127.0.0.1:8080',
+			authenticate: jest.fn(),
+		};
+
+		jest.spyOn(AthomCloudAPI.prototype, 'getAuthenticatedUser').mockResolvedValue({
+			getHomeys: () => [homey],
+			getHomeyById: () => homey,
+		} as unknown as AthomCloudAPI.User);
+		const provider = new HomeySdkClientFactoryService().createCloudProviderClient({
+			clientId: 'deployment-client-id',
+			clientSecret: 'deployment-client-secret',
+			redirectUrl: `https://panel.example.com${HOMEY_CLOUD_CALLBACK_PATH}`,
+			token: {
+				tokenType: 'bearer',
+				accessToken: 'candidate-access-token',
+				refreshToken: 'candidate-refresh-token',
+				expiresIn: 3600,
+				grantType: 'authorization_code',
+			},
+		});
+
+		await expect(provider.authenticateHomey('homey-one', new AbortController().signal)).rejects.toMatchObject({
+			name: 'HomeyCloudSdkProtocolError',
+		});
+		expect(homey.authenticate.mock.calls).toHaveLength(0);
+	});
+
 	it('propagates cancellation into the child Homey login requests', async () => {
 		let requestStartedResolve: (() => void) | null = null;
 		const requestStarted = new Promise<void>((resolve) => {
@@ -216,6 +250,7 @@ describe('HomeySdkClientFactoryService', () => {
 				name: 'Home',
 				apiVersion: 3,
 				platform: 'local',
+				remoteUrl: 'https://homey-one.connect.athom.com',
 				authenticate: jest.fn(async () => {
 					await sdkUtility.fetch(`http://127.0.0.1:${address.port}/login`, {}, 60_000);
 

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.spec.ts
@@ -223,6 +223,64 @@ describe('HomeySdkClientFactoryService', () => {
 		expect(homey.authenticate.mock.calls).toHaveLength(0);
 	});
 
+	it('preserves retryable HTTP status from child Homey SDK requests', async () => {
+		const server = createServer((_request, response) => {
+			response.writeHead(429, { 'Content-Type': 'text/plain' });
+			response.end('private rate-limit response');
+		});
+
+		server.listen(0, '127.0.0.1');
+		await once(server, 'listening');
+
+		try {
+			const address = server.address();
+
+			if (address === null || typeof address === 'string') throw new Error('Test server address is unavailable');
+
+			const sdkUtility = (
+				createRequire(__filename)('homey-api') as {
+					Util: {
+						fetch(url: string, options: RequestInit, timeoutDuration: number): Promise<Response>;
+					};
+				}
+			).Util;
+			const homey = {
+				id: 'homey-one',
+				name: 'Home',
+				apiVersion: 3,
+				platform: 'local',
+				remoteUrl: 'https://homey-one.connect.athom.com',
+				authenticate: jest.fn(() => sdkUtility.fetch(`http://127.0.0.1:${address.port}/discovery`, {}, 60_000)),
+			};
+
+			jest.spyOn(AthomCloudAPI.prototype, 'getAuthenticatedUser').mockResolvedValue({
+				getHomeys: () => [homey],
+				getHomeyById: () => homey,
+			} as unknown as AthomCloudAPI.User);
+			const provider = new HomeySdkClientFactoryService().createCloudProviderClient({
+				clientId: 'deployment-client-id',
+				clientSecret: 'deployment-client-secret',
+				redirectUrl: `https://panel.example.com${HOMEY_CLOUD_CALLBACK_PATH}`,
+				token: {
+					tokenType: 'bearer',
+					accessToken: 'candidate-access-token',
+					refreshToken: 'candidate-refresh-token',
+					expiresIn: 3600,
+					grantType: 'authorization_code',
+				},
+			});
+
+			await expect(provider.authenticateHomey('homey-one', new AbortController().signal)).rejects.toMatchObject({
+				statusCode: 429,
+			});
+		} finally {
+			server.closeAllConnections();
+			await new Promise<void>((resolve, reject) => {
+				server.close((error) => (error ? reject(error) : resolve()));
+			});
+		}
+	});
+
 	it('propagates cancellation into the child Homey login requests', async () => {
 		let requestStartedResolve: (() => void) | null = null;
 		const requestStarted = new Promise<void>((resolve) => {

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.spec.ts
@@ -26,9 +26,11 @@ describe('HomeySdkClientFactoryService', () => {
 			expires_in: 3600,
 			grant_type: 'authorization_code',
 		};
-		const authenticateWithAuthorizationCode = jest
-			.spyOn(AthomCloudAPI.prototype, 'authenticateWithAuthorizationCode')
-			.mockResolvedValue(token as unknown as AthomCloudAPI.Token);
+		const fetchMock = jest
+			.spyOn(globalThis, 'fetch')
+			.mockResolvedValue(
+				new Response(JSON.stringify(token), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+			);
 		const homeyApi = {
 			disconnect: jest.fn().mockResolvedValue(undefined),
 			destroy: jest.fn(),
@@ -63,18 +65,51 @@ describe('HomeySdkClientFactoryService', () => {
 			},
 		});
 
-		await expect(provider.exchangeAuthorizationCode('authorization-code')).resolves.toBe(token);
-		await expect(candidateProvider.getHomeys()).resolves.toEqual([
+		const controller = new AbortController();
+
+		await expect(provider.exchangeAuthorizationCode('authorization-code', controller.signal)).resolves.toEqual(token);
+		await expect(candidateProvider.getHomeys(controller.signal)).resolves.toEqual([
 			{ id: 'homey-one', name: 'Home', apiVersion: 3, platform: 'local' },
 		]);
-		await expect(candidateProvider.authenticateHomey('homey-one')).resolves.toBeUndefined();
-		expect(authenticateWithAuthorizationCode).toHaveBeenCalledWith({
-			code: 'authorization-code',
-			removeCodeFromHistory: false,
-		});
+		await expect(candidateProvider.authenticateHomey('homey-one', controller.signal)).resolves.toBeUndefined();
+		const [tokenUrl, tokenRequest] = fetchMock.mock.calls[0];
+
+		expect(tokenUrl).toBe('https://api.athom.com/oauth2/token');
+		expect(tokenRequest?.redirect).toBe('error');
+		expect(tokenRequest?.signal).toBeInstanceOf(AbortSignal);
+		expect(tokenRequest?.body).toBeInstanceOf(URLSearchParams);
+		expect((tokenRequest?.body as URLSearchParams).toString()).toBe(
+			'grant_type=authorization_code&code=authorization-code',
+		);
 		expect(homey.authenticate).toHaveBeenCalledWith({ strategy: 'cloud', reconnect: false });
 		expect(homeyApi.disconnect).toHaveBeenCalledTimes(1);
 		expect(homeyApi.destroy).toHaveBeenCalledTimes(1);
+	});
+
+	it('aborts the underlying authorization-code exchange when its caller cancels', async () => {
+		let requestSignal: AbortSignal | null = null;
+		jest.spyOn(globalThis, 'fetch').mockImplementation((_input, init) => {
+			requestSignal = init?.signal ?? null;
+
+			return new Promise((_resolve, reject) => {
+				requestSignal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')), {
+					once: true,
+				});
+			});
+		});
+		const factory = new HomeySdkClientFactoryService();
+		const provider = factory.createCloudProviderClient({
+			clientId: 'deployment-client-id',
+			clientSecret: 'deployment-client-secret',
+			redirectUrl: `https://panel.example.com${HOMEY_CLOUD_CALLBACK_PATH}`,
+		});
+		const controller = new AbortController();
+		const exchange = provider.exchangeAuthorizationCode('authorization-code', controller.signal);
+
+		controller.abort();
+
+		await expect(exchange).rejects.toMatchObject({ code: 'ABORTERROR' });
+		expect(requestSignal?.aborted).toBe(true);
 	});
 
 	it('creates a Homey Cloud authorization URL without exposing the client secret', () => {
@@ -100,7 +135,7 @@ describe('HomeySdkClientFactoryService', () => {
 		expect(result).not.toContain(clientSecret);
 	});
 
-	it('rejects an authorization URL redirected by the SDK base URL environment override', () => {
+	it('rejects authorization and provider clients redirected by the SDK base URL environment override', () => {
 		process.env.ATHOM_CLOUD_API_BASEURL = 'https://untrusted.example.com';
 		const factory = new HomeySdkClientFactoryService();
 
@@ -111,6 +146,13 @@ describe('HomeySdkClientFactoryService', () => {
 				redirectUrl: `https://panel.example.com${HOMEY_CLOUD_CALLBACK_PATH}`,
 				scopes: [...HOMEY_CLOUD_SCOPES],
 				state: 'single-use-random-state',
+			}),
+		).toThrow(HomeyCloudConfigurationError);
+		expect(() =>
+			factory.createCloudProviderClient({
+				clientId: 'deployment-client-id',
+				clientSecret: 'deployment-client-secret',
+				redirectUrl: `https://panel.example.com${HOMEY_CLOUD_CALLBACK_PATH}`,
 			}),
 		).toThrow(HomeyCloudConfigurationError);
 	});

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.spec.ts
@@ -115,6 +115,80 @@ describe('HomeySdkClientFactoryService', () => {
 		expect(requestSignal?.aborted).toBe(true);
 	});
 
+	it('classifies token HTTP failures before attempting to parse their body', async () => {
+		jest.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('not-json', { status: 429 }));
+		const provider = new HomeySdkClientFactoryService().createCloudProviderClient({
+			clientId: 'deployment-client-id',
+			clientSecret: 'deployment-client-secret',
+			redirectUrl: `https://panel.example.com${HOMEY_CLOUD_CALLBACK_PATH}`,
+		});
+
+		await expect(
+			provider.exchangeAuthorizationCode('authorization-code', new AbortController().signal),
+		).rejects.toMatchObject({
+			statusCode: 429,
+		});
+	});
+
+	it('keeps cancellation attached while the SDK consumes an account response body', async () => {
+		let bodyAborted = false;
+
+		jest.spyOn(globalThis, 'fetch').mockImplementation((_input, init) => {
+			const body = new ReadableStream({
+				start(controller) {
+					init?.signal?.addEventListener(
+						'abort',
+						() => {
+							bodyAborted = true;
+							controller.error(new DOMException('Aborted', 'AbortError'));
+						},
+						{ once: true },
+					);
+				},
+			});
+
+			return Promise.resolve(new Response(body, { headers: { 'Content-Type': 'application/json' } }));
+		});
+		jest.spyOn(AthomCloudAPI.prototype, 'getAuthenticatedUser').mockImplementation(async function () {
+			const executor = this as unknown as {
+				onCallRequestExecute(input: {
+					request: { body?: BodyInit; headers: HeadersInit; method: string; timeout?: number; url: string };
+				}): Promise<Response>;
+			};
+			const response = await executor.onCallRequestExecute({
+				request: {
+					headers: {},
+					method: 'GET',
+					timeout: 60_000,
+					url: 'https://api.athom.com/user/me',
+				},
+			});
+
+			await response.json();
+
+			throw new Error('The stalled SDK response body unexpectedly completed');
+		});
+		const provider = new HomeySdkClientFactoryService().createCloudProviderClient({
+			clientId: 'deployment-client-id',
+			clientSecret: 'deployment-client-secret',
+			redirectUrl: `https://panel.example.com${HOMEY_CLOUD_CALLBACK_PATH}`,
+			token: {
+				tokenType: 'bearer',
+				accessToken: 'candidate-access-token',
+				refreshToken: 'candidate-refresh-token',
+				expiresIn: 3600,
+				grantType: 'authorization_code',
+			},
+		});
+		const controller = new AbortController();
+		const listing = provider.getHomeys(controller.signal);
+
+		controller.abort();
+
+		await expect(listing).rejects.toMatchObject({ code: 'ABORTERROR' });
+		expect(bodyAborted).toBe(true);
+	});
+
 	it('propagates cancellation into the child Homey login requests', async () => {
 		let requestStartedResolve: (() => void) | null = null;
 		const requestStarted = new Promise<void>((resolve) => {

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.spec.ts
@@ -250,6 +250,36 @@ describe('HomeySdkClientFactoryService', () => {
 		expect(homey.authenticate.mock.calls).toHaveLength(0);
 	});
 
+	it('authenticates an API-v1 Homey without newer client lifecycle methods', async () => {
+		const homey = {
+			id: 'legacy-homey',
+			name: 'Legacy Homey',
+			apiVersion: 1,
+			platform: 'local',
+			authenticate: jest.fn().mockResolvedValue({}),
+		};
+
+		jest.spyOn(AthomCloudAPI.prototype, 'getAuthenticatedUser').mockResolvedValue({
+			getHomeys: () => [homey],
+			getHomeyById: () => homey,
+		} as unknown as AthomCloudAPI.User);
+		const provider = new HomeySdkClientFactoryService().createCloudProviderClient({
+			clientId: 'deployment-client-id',
+			clientSecret: 'deployment-client-secret',
+			redirectUrl: `https://panel.example.com${HOMEY_CLOUD_CALLBACK_PATH}`,
+			token: {
+				tokenType: 'bearer',
+				accessToken: 'candidate-access-token',
+				refreshToken: 'candidate-refresh-token',
+				expiresIn: 3600,
+				grantType: 'authorization_code',
+			},
+		});
+
+		await expect(provider.authenticateHomey('legacy-homey', new AbortController().signal)).resolves.toBeUndefined();
+		expect(homey.authenticate).toHaveBeenCalledWith({ strategy: 'cloud', reconnect: false });
+	});
+
 	it('preserves retryable HTTP status from child Homey SDK requests', async () => {
 		const server = createServer((_request, response) => {
 			response.writeHead(429, { 'Content-Type': 'text/plain' });

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.ts
@@ -446,7 +446,7 @@ function installHomeySdkAbortBridge(): AsyncLocalStorage<AbortSignal> {
 	const context = new AsyncLocalStorage<AbortSignal>();
 	const originalFetch = utility.fetch.bind(utility) as HomeySdkUtility['fetch'];
 
-	utility.fetch = (url, options = {}, _timeoutDuration, _timeoutMessage, patchOptions) => {
+	utility.fetch = async (url, options = {}, _timeoutDuration, _timeoutMessage, patchOptions) => {
 		const operationSignal = context.getStore();
 
 		if (!operationSignal) return originalFetch(url, options, _timeoutDuration, _timeoutMessage, patchOptions);
@@ -456,7 +456,20 @@ function installHomeySdkAbortBridge(): AsyncLocalStorage<AbortSignal> {
 
 		// The provider service owns the complete-operation deadline. Do not let the SDK replace the operation signal with a
 		// headers-only timeout controller that is detached before its response body has been consumed.
-		return originalFetch(url, { ...options, redirect: 'error', signal }, undefined, undefined, patchOptions);
+		const response = await originalFetch(
+			url,
+			{ ...options, redirect: 'error', signal },
+			undefined,
+			undefined,
+			patchOptions,
+		);
+
+		if (isRetryableHttpStatus(response.status)) {
+			discardResponseBody(response);
+			throw new HomeyCloudSdkHttpError(response.status);
+		}
+
+		return response;
 	};
 	Object.defineProperty(utility, 'fastyBirdAbortContext', {
 		configurable: false,
@@ -466,6 +479,20 @@ function installHomeySdkAbortBridge(): AsyncLocalStorage<AbortSignal> {
 	});
 
 	return context;
+}
+
+function isRetryableHttpStatus(statusCode: number): boolean {
+	return statusCode === 408 || statusCode === 429 || statusCode >= 500;
+}
+
+function discardResponseBody(response: Response): void {
+	const body = response.body as unknown as { cancel?: () => Promise<void>; destroy?: (error?: Error) => void } | null;
+
+	if (typeof body?.destroy === 'function') {
+		body.destroy();
+	} else if (typeof body?.cancel === 'function') {
+		void body.cancel().catch(() => undefined);
+	}
 }
 
 class HomeyCloudSdkHttpError extends Error {

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.ts
@@ -72,6 +72,41 @@ export interface HomeyCloudSdkClientFactory {
 		scopes: string[];
 		state: string;
 	}): string;
+	createCloudProviderClient(options: {
+		clientId: string;
+		clientSecret: string;
+		redirectUrl: string;
+		token?: HomeyCloudProviderToken;
+	}): HomeyCloudProviderClient;
+}
+
+export interface HomeyCloudProviderToken {
+	readonly accessToken: string;
+	readonly expiresIn: number | null;
+	readonly grantType: string | null;
+	readonly refreshToken: string | null;
+	readonly tokenType: string;
+}
+
+export interface HomeyCloudProviderTokenResponse {
+	readonly access_token?: unknown;
+	readonly expires_in?: unknown;
+	readonly grant_type?: unknown;
+	readonly refresh_token?: unknown;
+	readonly token_type?: unknown;
+}
+
+export interface HomeyCloudProviderHomey {
+	readonly apiVersion: unknown;
+	readonly id: unknown;
+	readonly name: unknown;
+	readonly platform: unknown;
+}
+
+export interface HomeyCloudProviderClient {
+	authenticateHomey(homeyId: string): Promise<void>;
+	exchangeAuthorizationCode(code: string): Promise<HomeyCloudProviderTokenResponse>;
+	getHomeys(): Promise<readonly HomeyCloudProviderHomey[]>;
 }
 
 @Injectable()
@@ -104,6 +139,39 @@ export class HomeySdkClientFactoryService implements HomeySdkClientFactory, Home
 		return authorizeUrl;
 	}
 
+	createCloudProviderClient(options: {
+		clientId: string;
+		clientSecret: string;
+		redirectUrl: string;
+		token?: HomeyCloudProviderToken;
+	}): HomeyCloudProviderClient {
+		const TokenConstructor = AthomCloudAPI.Token as unknown as new (properties: {
+			access_token: string;
+			expires_in?: number;
+			grant_type?: string;
+			refresh_token?: string;
+			token_type: string;
+		}) => AthomCloudAPI.Token;
+		const token = options.token
+			? new TokenConstructor({
+					token_type: options.token.tokenType,
+					access_token: options.token.accessToken,
+					refresh_token: options.token.refreshToken ?? undefined,
+					expires_in: options.token.expiresIn ?? undefined,
+					grant_type: options.token.grantType ?? undefined,
+				})
+			: undefined;
+		const cloudApi = new AthomCloudAPI({
+			clientId: options.clientId,
+			clientSecret: options.clientSecret,
+			redirectUrl: options.redirectUrl,
+			autoRefreshTokens: false,
+			token,
+		});
+
+		return new HomeyCloudProviderSdkClient(cloudApi);
+	}
+
 	private assertCloudAuthorizationEndpoint(value: string): void {
 		let url: URL;
 
@@ -116,5 +184,50 @@ export class HomeySdkClientFactoryService implements HomeySdkClientFactory, Home
 		if (url.username || url.password || url.origin + url.pathname !== HOMEY_CLOUD_AUTHORIZE_URL) {
 			throw new HomeyCloudConfigurationError('Homey Cloud authorization endpoint is invalid');
 		}
+	}
+}
+
+class HomeyCloudProviderSdkClient implements HomeyCloudProviderClient {
+	constructor(private readonly cloudApi: AthomCloudAPI) {}
+
+	async exchangeAuthorizationCode(code: string): Promise<HomeyCloudProviderTokenResponse> {
+		return this.cloudApi.authenticateWithAuthorizationCode({ code, removeCodeFromHistory: false });
+	}
+
+	async getHomeys(): Promise<readonly HomeyCloudProviderHomey[]> {
+		const user = await this.getAuthenticatedUserFresh();
+
+		return user.getHomeys().map((homey) => {
+			const properties = homey as unknown as Record<string, unknown>;
+
+			return {
+				id: homey.id,
+				name: properties.name,
+				apiVersion: properties.apiVersion,
+				platform: properties.platform,
+			};
+		});
+	}
+
+	async authenticateHomey(homeyId: string): Promise<void> {
+		const user = await this.getAuthenticatedUserFresh();
+		const homey = user.getHomeyById(homeyId) as unknown as {
+			authenticate(options: { reconnect: boolean; strategy: string }): Promise<HomeySdkClient>;
+		};
+		const homeyApi = await homey.authenticate({ strategy: 'cloud', reconnect: false });
+
+		try {
+			await homeyApi.disconnect();
+		} finally {
+			homeyApi.destroy();
+		}
+	}
+
+	private getAuthenticatedUserFresh(): Promise<AthomCloudAPI.User> {
+		const cloudApi = this.cloudApi as unknown as {
+			getAuthenticatedUser(options: { $cache: boolean }): Promise<AthomCloudAPI.User>;
+		};
+
+		return cloudApi.getAuthenticatedUser({ $cache: false });
 	}
 }

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.ts
@@ -254,7 +254,10 @@ class HomeyCloudProviderSdkClient implements HomeyCloudProviderClient {
 		);
 		let body: unknown;
 
-		if (!response.ok) throw new HomeyCloudSdkHttpError(response.status);
+		if (!response.ok) {
+			discardResponseBody(response);
+			throw new HomeyCloudSdkHttpError(response.status);
+		}
 
 		try {
 			body = await response.json();

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.ts
@@ -1,4 +1,6 @@
 import { AthomCloudAPI, HomeyAPI } from 'homey-api';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { createRequire } from 'node:module';
 
 import { Injectable } from '@nestjs/common';
 
@@ -9,6 +11,8 @@ import {
 	HOMEY_CLOUD_TOKEN_URL,
 } from '../devices-homey.constants';
 import { HomeyCloudConfigurationError } from '../errors/homey-cloud-authorization.error';
+
+const homeySdkAbortContext = installHomeySdkAbortBridge();
 
 export type HomeySdkEventListener = (...arguments_: unknown[]) => Promise<void> | void;
 
@@ -309,7 +313,11 @@ class HomeyCloudProviderSdkClient implements HomeyCloudProviderClient {
 		this.activeSignal = signal;
 
 		try {
-			return await operation();
+			return await homeySdkAbortContext.run(signal, operation);
+		} catch (error) {
+			if (signal.aborted) throw new HomeyCloudSdkAbortError();
+
+			throw error;
 		} finally {
 			this.activeSignal = null;
 		}
@@ -386,6 +394,47 @@ interface HomeyCloudSdkRequest {
 interface HomeyCloudApiExecutor {
 	baseUrl: string;
 	onCallRequestExecute(input: { request: HomeyCloudSdkRequest }): Promise<Response>;
+}
+
+interface HomeySdkUtility {
+	readonly fastyBirdAbortContext?: AsyncLocalStorage<AbortSignal>;
+	fetch: (
+		url: string,
+		options?: RequestInit,
+		timeoutDuration?: number,
+		timeoutMessage?: string,
+		patchOptions?: (options: RequestInit, url: string) => RequestInit | void,
+	) => Promise<Response>;
+}
+
+function installHomeySdkAbortBridge(): AsyncLocalStorage<AbortSignal> {
+	const loadModule = createRequire(__filename) as (moduleId: string) => unknown;
+	const homeyApiModule = loadModule('homey-api') as { Util: HomeySdkUtility };
+	const utility = homeyApiModule.Util;
+
+	if (utility.fastyBirdAbortContext) return utility.fastyBirdAbortContext;
+
+	const context = new AsyncLocalStorage<AbortSignal>();
+	const originalFetch = utility.fetch.bind(utility) as HomeySdkUtility['fetch'];
+
+	utility.fetch = (url, options = {}, timeoutDuration, timeoutMessage, patchOptions) => {
+		const operationSignal = context.getStore();
+
+		if (!operationSignal) return originalFetch(url, options, timeoutDuration, timeoutMessage, patchOptions);
+
+		const existingSignal = options.signal;
+		const signal = existingSignal ? AbortSignal.any([existingSignal, operationSignal]) : operationSignal;
+
+		return originalFetch(url, { ...options, signal }, timeoutDuration, timeoutMessage, patchOptions);
+	};
+	Object.defineProperty(utility, 'fastyBirdAbortContext', {
+		configurable: false,
+		enumerable: false,
+		value: context,
+		writable: false,
+	});
+
+	return context;
 }
 
 class HomeyCloudSdkHttpError extends Error {

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.ts
@@ -8,12 +8,16 @@ import {
 	HOMEY_CLOUD_API_URL,
 	HOMEY_CLOUD_AUTHORIZE_URL,
 	HOMEY_CLOUD_HOMEY_HOST_SUFFIX,
+	HOMEY_CLOUD_MAX_HOMEY_ID_LENGTH,
 	HOMEY_CLOUD_PROVIDER_TIMEOUT_MS,
 	HOMEY_CLOUD_TOKEN_URL,
 } from '../devices-homey.constants';
 import { HomeyCloudConfigurationError, HomeyCloudSelectionError } from '../errors/homey-cloud-authorization.error';
 
 const homeySdkAbortContext = installHomeySdkAbortBridge();
+const SUPPORTED_HOMEY_CLOUD_API_VERSIONS = new Set([1, 2, 3]);
+const SUPPORTED_HOMEY_CLOUD_PLATFORMS = new Set(['cloud', 'local']);
+const UNICODE_CONTROL_PATTERN = /[\p{Cc}\p{Cf}]/u;
 
 export type HomeySdkEventListener = (...arguments_: unknown[]) => Promise<void> | void;
 
@@ -112,6 +116,24 @@ export interface HomeyCloudProviderHomey {
 	readonly name: unknown;
 	readonly platform: unknown;
 }
+
+export const isEligibleHomeyCloudProviderHomey = (
+	homey: unknown,
+): homey is HomeyCloudProviderHomey & { readonly id: string } => {
+	if (typeof homey !== 'object' || homey === null || Array.isArray(homey)) return false;
+
+	const record = homey as Record<string, unknown>;
+
+	return (
+		SUPPORTED_HOMEY_CLOUD_API_VERSIONS.has(record.apiVersion as number) &&
+		SUPPORTED_HOMEY_CLOUD_PLATFORMS.has(record.platform as string) &&
+		typeof record.id === 'string' &&
+		record.id === record.id.trim() &&
+		record.id.length > 0 &&
+		record.id.length <= HOMEY_CLOUD_MAX_HOMEY_ID_LENGTH &&
+		![...record.id].some((character) => UNICODE_CONTROL_PATTERN.test(character))
+	);
+};
 
 export interface HomeyCloudProviderClient {
 	authenticateHomey(homeyId: string, signal: AbortSignal, requireSingleton: boolean): Promise<void>;
@@ -293,21 +315,22 @@ class HomeyCloudProviderSdkClient implements HomeyCloudProviderClient {
 	async authenticateHomey(homeyId: string, signal: AbortSignal, requireSingleton: boolean): Promise<void> {
 		return this.withSignal(signal, async () => {
 			const user = await this.getAuthenticatedUserFresh();
-			const homeys = user.getHomeys();
+			const homeys = user.getHomeys().filter(isEligibleHomeyCloudProviderHomey);
+			const homey = homeys.find((candidate) => candidate.id === homeyId);
 
-			if (requireSingleton && (homeys.length !== 1 || homeys[0]?.id !== homeyId)) {
+			if (!homey || (requireSingleton && homeys.length !== 1)) {
 				throw new HomeyCloudSelectionError();
 			}
 
-			const homey = user.getHomeyById(homeyId) as unknown as {
+			const authenticatableHomey = homey as unknown as {
 				apiVersion?: unknown;
 				authenticate(options: { reconnect: boolean; strategy: string }): Promise<HomeyCloudAuthenticatedSdkClient>;
 				remoteUrl?: unknown;
 			};
 
-			if (homey.apiVersion !== 1) this.assertHomeyCloudEndpoint(homey.remoteUrl);
+			if (authenticatableHomey.apiVersion !== 1) this.assertHomeyCloudEndpoint(authenticatableHomey.remoteUrl);
 
-			const homeyApi = await homey.authenticate({ strategy: 'cloud', reconnect: false });
+			const homeyApi = await authenticatableHomey.authenticate({ strategy: 'cloud', reconnect: false });
 
 			try {
 				if (typeof homeyApi.disconnect === 'function') await homeyApi.disconnect();

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.ts
@@ -2,7 +2,12 @@ import { AthomCloudAPI, HomeyAPI } from 'homey-api';
 
 import { Injectable } from '@nestjs/common';
 
-import { HOMEY_CLOUD_AUTHORIZE_URL } from '../devices-homey.constants';
+import {
+	HOMEY_CLOUD_API_URL,
+	HOMEY_CLOUD_AUTHORIZE_URL,
+	HOMEY_CLOUD_PROVIDER_TIMEOUT_MS,
+	HOMEY_CLOUD_TOKEN_URL,
+} from '../devices-homey.constants';
 import { HomeyCloudConfigurationError } from '../errors/homey-cloud-authorization.error';
 
 export type HomeySdkEventListener = (...arguments_: unknown[]) => Promise<void> | void;
@@ -104,9 +109,9 @@ export interface HomeyCloudProviderHomey {
 }
 
 export interface HomeyCloudProviderClient {
-	authenticateHomey(homeyId: string): Promise<void>;
-	exchangeAuthorizationCode(code: string): Promise<HomeyCloudProviderTokenResponse>;
-	getHomeys(): Promise<readonly HomeyCloudProviderHomey[]>;
+	authenticateHomey(homeyId: string, signal: AbortSignal): Promise<void>;
+	exchangeAuthorizationCode(code: string, signal: AbortSignal): Promise<HomeyCloudProviderTokenResponse>;
+	getHomeys(signal: AbortSignal): Promise<readonly HomeyCloudProviderHomey[]>;
 }
 
 @Injectable()
@@ -168,8 +173,11 @@ export class HomeySdkClientFactoryService implements HomeySdkClientFactory, Home
 			autoRefreshTokens: false,
 			token,
 		});
+		const cloudApiBaseUrl = (cloudApi as unknown as { baseUrl: unknown }).baseUrl;
 
-		return new HomeyCloudProviderSdkClient(cloudApi);
+		this.assertCloudApiEndpoint(cloudApiBaseUrl);
+
+		return new HomeyCloudProviderSdkClient(cloudApi, options.clientId, options.clientSecret);
 	}
 
 	private assertCloudAuthorizationEndpoint(value: string): void {
@@ -185,42 +193,105 @@ export class HomeySdkClientFactoryService implements HomeySdkClientFactory, Home
 			throw new HomeyCloudConfigurationError('Homey Cloud authorization endpoint is invalid');
 		}
 	}
+
+	private assertCloudApiEndpoint(value: unknown): void {
+		if (typeof value !== 'string') {
+			throw new HomeyCloudConfigurationError('Homey Cloud provider endpoint is invalid');
+		}
+
+		let url: URL;
+
+		try {
+			url = new URL(value);
+		} catch {
+			throw new HomeyCloudConfigurationError('Homey Cloud provider endpoint is invalid');
+		}
+
+		if (
+			url.username ||
+			url.password ||
+			url.search ||
+			url.hash ||
+			url.origin + url.pathname !== HOMEY_CLOUD_API_URL + '/'
+		) {
+			throw new HomeyCloudConfigurationError('Homey Cloud provider endpoint is invalid');
+		}
+	}
 }
 
 class HomeyCloudProviderSdkClient implements HomeyCloudProviderClient {
-	constructor(private readonly cloudApi: AthomCloudAPI) {}
+	private activeSignal: AbortSignal | null = null;
 
-	async exchangeAuthorizationCode(code: string): Promise<HomeyCloudProviderTokenResponse> {
-		return this.cloudApi.authenticateWithAuthorizationCode({ code, removeCodeFromHistory: false });
+	constructor(
+		private readonly cloudApi: AthomCloudAPI,
+		private readonly clientId: string,
+		private readonly clientSecret: string,
+	) {
+		const cloudApiExecutor = this.cloudApi as unknown as HomeyCloudApiExecutor;
+
+		cloudApiExecutor.onCallRequestExecute = ({ request }) => this.executeSdkRequest(request);
 	}
 
-	async getHomeys(): Promise<readonly HomeyCloudProviderHomey[]> {
-		const user = await this.getAuthenticatedUserFresh();
+	async exchangeAuthorizationCode(code: string, signal: AbortSignal): Promise<HomeyCloudProviderTokenResponse> {
+		const response = await this.executeFetch(
+			HOMEY_CLOUD_TOKEN_URL,
+			{
+				method: 'POST',
+				headers: {
+					Authorization: `Basic ${Buffer.from(`${this.clientId}:${this.clientSecret}`).toString('base64')}`,
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+				body: new URLSearchParams({ grant_type: 'authorization_code', code }),
+				redirect: 'error',
+			},
+			signal,
+			HOMEY_CLOUD_PROVIDER_TIMEOUT_MS,
+		);
+		let body: unknown;
 
-		return user.getHomeys().map((homey) => {
-			const properties = homey as unknown as Record<string, unknown>;
+		try {
+			body = await response.json();
+		} catch {
+			throw new HomeyCloudSdkProtocolError();
+		}
 
-			return {
-				id: homey.id,
-				name: properties.name,
-				apiVersion: properties.apiVersion,
-				platform: properties.platform,
-			};
+		if (!response.ok) throw new HomeyCloudSdkHttpError(response.status);
+		if (typeof body !== 'object' || body === null || Array.isArray(body)) throw new HomeyCloudSdkProtocolError();
+
+		return body as HomeyCloudProviderTokenResponse;
+	}
+
+	async getHomeys(signal: AbortSignal): Promise<readonly HomeyCloudProviderHomey[]> {
+		return this.withSignal(signal, async () => {
+			const user = await this.getAuthenticatedUserFresh();
+
+			return user.getHomeys().map((homey) => {
+				const properties = homey as unknown as Record<string, unknown>;
+
+				return {
+					id: homey.id,
+					name: properties.name,
+					apiVersion: properties.apiVersion,
+					platform: properties.platform,
+				};
+			});
 		});
 	}
 
-	async authenticateHomey(homeyId: string): Promise<void> {
-		const user = await this.getAuthenticatedUserFresh();
-		const homey = user.getHomeyById(homeyId) as unknown as {
-			authenticate(options: { reconnect: boolean; strategy: string }): Promise<HomeySdkClient>;
-		};
-		const homeyApi = await homey.authenticate({ strategy: 'cloud', reconnect: false });
+	async authenticateHomey(homeyId: string, signal: AbortSignal): Promise<void> {
+		return this.withSignal(signal, async () => {
+			const user = await this.getAuthenticatedUserFresh();
+			const homey = user.getHomeyById(homeyId) as unknown as {
+				authenticate(options: { reconnect: boolean; strategy: string }): Promise<HomeySdkClient>;
+			};
+			const homeyApi = await homey.authenticate({ strategy: 'cloud', reconnect: false });
 
-		try {
-			await homeyApi.disconnect();
-		} finally {
-			homeyApi.destroy();
-		}
+			try {
+				await homeyApi.disconnect();
+			} finally {
+				homeyApi.destroy();
+			}
+		});
 	}
 
 	private getAuthenticatedUserFresh(): Promise<AthomCloudAPI.User> {
@@ -229,5 +300,125 @@ class HomeyCloudProviderSdkClient implements HomeyCloudProviderClient {
 		};
 
 		return cloudApi.getAuthenticatedUser({ $cache: false });
+	}
+
+	private async withSignal<T>(signal: AbortSignal, operation: () => Promise<T>): Promise<T> {
+		if (signal.aborted) throw new HomeyCloudSdkAbortError();
+		if (this.activeSignal) throw new HomeyCloudSdkProtocolError();
+
+		this.activeSignal = signal;
+
+		try {
+			return await operation();
+		} finally {
+			this.activeSignal = null;
+		}
+	}
+
+	private executeSdkRequest(request: HomeyCloudSdkRequest): Promise<Response> {
+		this.assertProviderRequestUrl(request.url);
+
+		return this.executeFetch(
+			request.url,
+			{
+				method: request.method,
+				headers: request.headers,
+				body: request.body,
+				redirect: 'error',
+			},
+			this.activeSignal,
+			request.timeout ?? HOMEY_CLOUD_PROVIDER_TIMEOUT_MS,
+		);
+	}
+
+	private async executeFetch(
+		url: string,
+		options: RequestInit,
+		externalSignal: AbortSignal | null,
+		timeoutMs: number,
+	): Promise<Response> {
+		const controller = new AbortController();
+		let timedOut = false;
+		const abort = (): void => controller.abort(externalSignal?.reason);
+		const timeout = setTimeout(() => {
+			timedOut = true;
+			controller.abort();
+		}, timeoutMs);
+
+		timeout.unref();
+		if (externalSignal?.aborted) abort();
+		else externalSignal?.addEventListener('abort', abort, { once: true });
+
+		try {
+			return await fetch(url, { ...options, signal: controller.signal });
+		} catch (error) {
+			if (timedOut) throw new HomeyCloudSdkTimeoutError();
+			if (controller.signal.aborted) throw new HomeyCloudSdkAbortError();
+
+			throw error;
+		} finally {
+			clearTimeout(timeout);
+			externalSignal?.removeEventListener('abort', abort);
+		}
+	}
+
+	private assertProviderRequestUrl(value: string): void {
+		let url: URL;
+
+		try {
+			url = new URL(value);
+		} catch {
+			throw new HomeyCloudSdkProtocolError();
+		}
+
+		if (url.username || url.password || url.origin !== HOMEY_CLOUD_API_URL) throw new HomeyCloudSdkProtocolError();
+	}
+}
+
+interface HomeyCloudSdkRequest {
+	readonly body?: BodyInit;
+	readonly headers: HeadersInit;
+	readonly method: string;
+	readonly timeout?: number;
+	readonly url: string;
+}
+
+interface HomeyCloudApiExecutor {
+	baseUrl: string;
+	onCallRequestExecute(input: { request: HomeyCloudSdkRequest }): Promise<Response>;
+}
+
+class HomeyCloudSdkHttpError extends Error {
+	readonly statusCode: number;
+
+	constructor(statusCode: number) {
+		super('Homey Cloud provider request failed');
+		this.name = 'HomeyCloudSdkHttpError';
+		this.statusCode = statusCode;
+	}
+}
+
+class HomeyCloudSdkProtocolError extends Error {
+	constructor() {
+		super('Homey Cloud provider response is invalid');
+		this.name = 'HomeyCloudSdkProtocolError';
+	}
+}
+
+class HomeyCloudSdkAbortError extends Error {
+	readonly code = 'ABORTERROR';
+
+	constructor() {
+		super('Homey Cloud provider request was aborted');
+		this.name = 'HomeyCloudSdkAbortError';
+	}
+}
+
+class HomeyCloudSdkTimeoutError extends Error {
+	readonly statusCode = 408;
+
+	constructor() {
+		super('Homey Cloud provider request timed out');
+		this.name = 'HomeyCloudSdkTimeoutError';
 	}
 }

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.ts
@@ -291,18 +291,19 @@ class HomeyCloudProviderSdkClient implements HomeyCloudProviderClient {
 		return this.withSignal(signal, async () => {
 			const user = await this.getAuthenticatedUserFresh();
 			const homey = user.getHomeyById(homeyId) as unknown as {
-				authenticate(options: { reconnect: boolean; strategy: string }): Promise<HomeySdkClient>;
+				apiVersion?: unknown;
+				authenticate(options: { reconnect: boolean; strategy: string }): Promise<HomeyCloudAuthenticatedSdkClient>;
 				remoteUrl?: unknown;
 			};
 
-			this.assertHomeyCloudEndpoint(homey.remoteUrl);
+			if (homey.apiVersion !== 1) this.assertHomeyCloudEndpoint(homey.remoteUrl);
 
 			const homeyApi = await homey.authenticate({ strategy: 'cloud', reconnect: false });
 
 			try {
-				await homeyApi.disconnect();
+				if (typeof homeyApi.disconnect === 'function') await homeyApi.disconnect();
 			} finally {
-				homeyApi.destroy();
+				if (typeof homeyApi.destroy === 'function') homeyApi.destroy();
 			}
 		});
 	}
@@ -431,6 +432,11 @@ interface HomeyCloudApiExecutor {
 interface HomeyCloudFetchResult {
 	readonly response: Response;
 	readonly timeoutSignal: AbortSignal;
+}
+
+interface HomeyCloudAuthenticatedSdkClient {
+	destroy?: () => void;
+	disconnect?: () => Promise<void>;
 }
 
 interface HomeySdkUtility {

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.ts
@@ -7,6 +7,7 @@ import { Injectable } from '@nestjs/common';
 import {
 	HOMEY_CLOUD_API_URL,
 	HOMEY_CLOUD_AUTHORIZE_URL,
+	HOMEY_CLOUD_HOMEY_HOST_SUFFIX,
 	HOMEY_CLOUD_PROVIDER_TIMEOUT_MS,
 	HOMEY_CLOUD_TOKEN_URL,
 } from '../devices-homey.constants';
@@ -290,7 +291,11 @@ class HomeyCloudProviderSdkClient implements HomeyCloudProviderClient {
 			const user = await this.getAuthenticatedUserFresh();
 			const homey = user.getHomeyById(homeyId) as unknown as {
 				authenticate(options: { reconnect: boolean; strategy: string }): Promise<HomeySdkClient>;
+				remoteUrl?: unknown;
 			};
+
+			this.assertHomeyCloudEndpoint(homey.remoteUrl);
+
 			const homeyApi = await homey.authenticate({ strategy: 'cloud', reconnect: false });
 
 			try {
@@ -372,6 +377,39 @@ class HomeyCloudProviderSdkClient implements HomeyCloudProviderClient {
 
 		if (url.username || url.password || url.origin !== HOMEY_CLOUD_API_URL) throw new HomeyCloudSdkProtocolError();
 	}
+
+	private assertHomeyCloudEndpoint(value: unknown): void {
+		if (typeof value !== 'string') throw new HomeyCloudSdkProtocolError();
+
+		let url: URL;
+
+		try {
+			url = new URL(value);
+		} catch {
+			throw new HomeyCloudSdkProtocolError();
+		}
+
+		const homeyHost = url.hostname.endsWith(HOMEY_CLOUD_HOMEY_HOST_SUFFIX)
+			? url.hostname.slice(0, -HOMEY_CLOUD_HOMEY_HOST_SUFFIX.length)
+			: '';
+
+		if (
+			url.protocol !== 'https:' ||
+			url.username ||
+			url.password ||
+			url.port ||
+			url.pathname !== '/' ||
+			url.search ||
+			url.hash ||
+			!this.isDnsLabel(homeyHost)
+		) {
+			throw new HomeyCloudSdkProtocolError();
+		}
+	}
+
+	private isDnsLabel(value: string): boolean {
+		return /^[a-z\d](?:[a-z\d-]{0,61}[a-z\d])?$/iu.test(value);
+	}
 }
 
 interface HomeyCloudSdkRequest {
@@ -418,7 +456,7 @@ function installHomeySdkAbortBridge(): AsyncLocalStorage<AbortSignal> {
 
 		// The provider service owns the complete-operation deadline. Do not let the SDK replace the operation signal with a
 		// headers-only timeout controller that is detached before its response body has been consumed.
-		return originalFetch(url, { ...options, signal }, undefined, undefined, patchOptions);
+		return originalFetch(url, { ...options, redirect: 'error', signal }, undefined, undefined, patchOptions);
 	};
 	Object.defineProperty(utility, 'fastyBirdAbortContext', {
 		configurable: false,

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.ts
@@ -11,7 +11,7 @@ import {
 	HOMEY_CLOUD_PROVIDER_TIMEOUT_MS,
 	HOMEY_CLOUD_TOKEN_URL,
 } from '../devices-homey.constants';
-import { HomeyCloudConfigurationError } from '../errors/homey-cloud-authorization.error';
+import { HomeyCloudConfigurationError, HomeyCloudSelectionError } from '../errors/homey-cloud-authorization.error';
 
 const homeySdkAbortContext = installHomeySdkAbortBridge();
 
@@ -114,7 +114,7 @@ export interface HomeyCloudProviderHomey {
 }
 
 export interface HomeyCloudProviderClient {
-	authenticateHomey(homeyId: string, signal: AbortSignal): Promise<void>;
+	authenticateHomey(homeyId: string, signal: AbortSignal, requireSingleton: boolean): Promise<void>;
 	exchangeAuthorizationCode(code: string, signal: AbortSignal): Promise<HomeyCloudProviderTokenResponse>;
 	getHomeys(signal: AbortSignal): Promise<readonly HomeyCloudProviderHomey[]>;
 }
@@ -290,9 +290,15 @@ class HomeyCloudProviderSdkClient implements HomeyCloudProviderClient {
 		});
 	}
 
-	async authenticateHomey(homeyId: string, signal: AbortSignal): Promise<void> {
+	async authenticateHomey(homeyId: string, signal: AbortSignal, requireSingleton: boolean): Promise<void> {
 		return this.withSignal(signal, async () => {
 			const user = await this.getAuthenticatedUserFresh();
+			const homeys = user.getHomeys();
+
+			if (requireSingleton && (homeys.length !== 1 || homeys[0]?.id !== homeyId)) {
+				throw new HomeyCloudSelectionError();
+			}
+
 			const homey = user.getHomeyById(homeyId) as unknown as {
 				apiVersion?: unknown;
 				authenticate(options: { reconnect: boolean; strategy: string }): Promise<HomeyCloudAuthenticatedSdkClient>;

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.ts
@@ -17,7 +17,7 @@ import { HomeyCloudConfigurationError, HomeyCloudSelectionError } from '../error
 const homeySdkAbortContext = installHomeySdkAbortBridge();
 const SUPPORTED_HOMEY_CLOUD_API_VERSIONS = new Set([1, 2, 3]);
 const SUPPORTED_HOMEY_CLOUD_PLATFORMS = new Set(['cloud', 'local']);
-const UNICODE_CONTROL_PATTERN = /[\p{Cc}\p{Cf}]/u;
+const HOMEY_CLOUD_ID_UNSAFE_PATTERN = /[\s\p{Cc}\p{Cf}\p{Z}]/u;
 
 export type HomeySdkEventListener = (...arguments_: unknown[]) => Promise<void> | void;
 
@@ -117,6 +117,12 @@ export interface HomeyCloudProviderHomey {
 	readonly platform: unknown;
 }
 
+export const isSafeHomeyCloudProviderHomeyId = (id: unknown): id is string =>
+	typeof id === 'string' &&
+	id.length > 0 &&
+	id.length <= HOMEY_CLOUD_MAX_HOMEY_ID_LENGTH &&
+	![...id].some((character) => HOMEY_CLOUD_ID_UNSAFE_PATTERN.test(character));
+
 export const isEligibleHomeyCloudProviderHomey = (
 	homey: unknown,
 ): homey is HomeyCloudProviderHomey & { readonly id: string } => {
@@ -127,11 +133,7 @@ export const isEligibleHomeyCloudProviderHomey = (
 	return (
 		SUPPORTED_HOMEY_CLOUD_API_VERSIONS.has(record.apiVersion as number) &&
 		SUPPORTED_HOMEY_CLOUD_PLATFORMS.has(record.platform as string) &&
-		typeof record.id === 'string' &&
-		record.id === record.id.trim() &&
-		record.id.length > 0 &&
-		record.id.length <= HOMEY_CLOUD_MAX_HOMEY_ID_LENGTH &&
-		![...record.id].some((character) => UNICODE_CONTROL_PATTERN.test(character))
+		isSafeHomeyCloudProviderHomeyId(record.id)
 	);
 };
 
@@ -316,6 +318,10 @@ class HomeyCloudProviderSdkClient implements HomeyCloudProviderClient {
 		return this.withSignal(signal, async () => {
 			const user = await this.getAuthenticatedUserFresh();
 			const homeys = user.getHomeys().filter(isEligibleHomeyCloudProviderHomey);
+			const identifiers = new Set(homeys.map((homey) => homey.id));
+
+			if (identifiers.size !== homeys.length) throw new HomeyCloudSdkProtocolError();
+
 			const homey = homeys.find((candidate) => candidate.id === homeyId);
 
 			if (!homey || (requireSingleton && homeys.length !== 1)) {

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.ts
@@ -238,7 +238,7 @@ class HomeyCloudProviderSdkClient implements HomeyCloudProviderClient {
 	}
 
 	async exchangeAuthorizationCode(code: string, signal: AbortSignal): Promise<HomeyCloudProviderTokenResponse> {
-		const response = await this.executeFetch(
+		const { response, timeoutSignal } = await this.executeFetch(
 			HOMEY_CLOUD_TOKEN_URL,
 			{
 				method: 'POST',
@@ -259,6 +259,7 @@ class HomeyCloudProviderSdkClient implements HomeyCloudProviderClient {
 		try {
 			body = await response.json();
 		} catch {
+			if (timeoutSignal.aborted) throw new HomeyCloudSdkTimeoutError();
 			if (signal.aborted) throw new HomeyCloudSdkAbortError();
 
 			throw new HomeyCloudSdkProtocolError();
@@ -344,7 +345,7 @@ class HomeyCloudProviderSdkClient implements HomeyCloudProviderClient {
 			},
 			this.activeSignal,
 			request.timeout ?? HOMEY_CLOUD_PROVIDER_TIMEOUT_MS,
-		);
+		).then(({ response }) => response);
 	}
 
 	private async executeFetch(
@@ -352,12 +353,14 @@ class HomeyCloudProviderSdkClient implements HomeyCloudProviderClient {
 		options: RequestInit,
 		externalSignal: AbortSignal | null,
 		timeoutMs: number,
-	): Promise<Response> {
+	): Promise<HomeyCloudFetchResult> {
 		const timeoutSignal = AbortSignal.timeout(timeoutMs);
 		const signal = externalSignal ? AbortSignal.any([externalSignal, timeoutSignal]) : timeoutSignal;
 
 		try {
-			return await fetch(url, { ...options, signal });
+			const response = await fetch(url, { ...options, signal });
+
+			return { response, timeoutSignal };
 		} catch (error) {
 			if (timeoutSignal.aborted) throw new HomeyCloudSdkTimeoutError();
 			if (externalSignal?.aborted) throw new HomeyCloudSdkAbortError();
@@ -423,6 +426,11 @@ interface HomeyCloudSdkRequest {
 interface HomeyCloudApiExecutor {
 	baseUrl: string;
 	onCallRequestExecute(input: { request: HomeyCloudSdkRequest }): Promise<Response>;
+}
+
+interface HomeyCloudFetchResult {
+	readonly response: Response;
+	readonly timeoutSignal: AbortSignal;
 }
 
 interface HomeySdkUtility {

--- a/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.ts
+++ b/apps/backend/src/plugins/devices-homey/connectors/homey-sdk.client.ts
@@ -253,13 +253,16 @@ class HomeyCloudProviderSdkClient implements HomeyCloudProviderClient {
 		);
 		let body: unknown;
 
+		if (!response.ok) throw new HomeyCloudSdkHttpError(response.status);
+
 		try {
 			body = await response.json();
 		} catch {
+			if (signal.aborted) throw new HomeyCloudSdkAbortError();
+
 			throw new HomeyCloudSdkProtocolError();
 		}
 
-		if (!response.ok) throw new HomeyCloudSdkHttpError(response.status);
 		if (typeof body !== 'object' || body === null || Array.isArray(body)) throw new HomeyCloudSdkProtocolError();
 
 		return body as HomeyCloudProviderTokenResponse;
@@ -345,28 +348,16 @@ class HomeyCloudProviderSdkClient implements HomeyCloudProviderClient {
 		externalSignal: AbortSignal | null,
 		timeoutMs: number,
 	): Promise<Response> {
-		const controller = new AbortController();
-		let timedOut = false;
-		const abort = (): void => controller.abort(externalSignal?.reason);
-		const timeout = setTimeout(() => {
-			timedOut = true;
-			controller.abort();
-		}, timeoutMs);
-
-		timeout.unref();
-		if (externalSignal?.aborted) abort();
-		else externalSignal?.addEventListener('abort', abort, { once: true });
+		const timeoutSignal = AbortSignal.timeout(timeoutMs);
+		const signal = externalSignal ? AbortSignal.any([externalSignal, timeoutSignal]) : timeoutSignal;
 
 		try {
-			return await fetch(url, { ...options, signal: controller.signal });
+			return await fetch(url, { ...options, signal });
 		} catch (error) {
-			if (timedOut) throw new HomeyCloudSdkTimeoutError();
-			if (controller.signal.aborted) throw new HomeyCloudSdkAbortError();
+			if (timeoutSignal.aborted) throw new HomeyCloudSdkTimeoutError();
+			if (externalSignal?.aborted) throw new HomeyCloudSdkAbortError();
 
 			throw error;
-		} finally {
-			clearTimeout(timeout);
-			externalSignal?.removeEventListener('abort', abort);
 		}
 	}
 
@@ -417,15 +408,17 @@ function installHomeySdkAbortBridge(): AsyncLocalStorage<AbortSignal> {
 	const context = new AsyncLocalStorage<AbortSignal>();
 	const originalFetch = utility.fetch.bind(utility) as HomeySdkUtility['fetch'];
 
-	utility.fetch = (url, options = {}, timeoutDuration, timeoutMessage, patchOptions) => {
+	utility.fetch = (url, options = {}, _timeoutDuration, _timeoutMessage, patchOptions) => {
 		const operationSignal = context.getStore();
 
-		if (!operationSignal) return originalFetch(url, options, timeoutDuration, timeoutMessage, patchOptions);
+		if (!operationSignal) return originalFetch(url, options, _timeoutDuration, _timeoutMessage, patchOptions);
 
 		const existingSignal = options.signal;
 		const signal = existingSignal ? AbortSignal.any([existingSignal, operationSignal]) : operationSignal;
 
-		return originalFetch(url, { ...options, signal }, timeoutDuration, timeoutMessage, patchOptions);
+		// The provider service owns the complete-operation deadline. Do not let the SDK replace the operation signal with a
+		// headers-only timeout controller that is detached before its response body has been consumed.
+		return originalFetch(url, { ...options, signal }, undefined, undefined, patchOptions);
 	};
 	Object.defineProperty(utility, 'fastyBirdAbortContext', {
 		configurable: false,

--- a/apps/backend/src/plugins/devices-homey/devices-homey.constants.ts
+++ b/apps/backend/src/plugins/devices-homey/devices-homey.constants.ts
@@ -68,6 +68,16 @@ export const HOMEY_CLOUD_PENDING_GRANT_TTL_MS = 10 * 60 * 1000;
 
 export const HOMEY_CLOUD_PENDING_GRANT_CLEANUP_INTERVAL_MS = 60 * 1000;
 
+export const HOMEY_CLOUD_PROVIDER_TIMEOUT_MS = 10 * 1000;
+
+export const HOMEY_CLOUD_MAX_AUTHORIZATION_CODE_LENGTH = 4096;
+
+export const HOMEY_CLOUD_MAX_TOKEN_LENGTH = 16 * 1024;
+
+export const HOMEY_CLOUD_MAX_HOMEY_ID_LENGTH = 255;
+
+export const HOMEY_CLOUD_MAX_HOMEY_NAME_LENGTH = 120;
+
 export enum HomeyConnectionState {
 	STOPPED = 'stopped',
 	CONNECTING = 'connecting',

--- a/apps/backend/src/plugins/devices-homey/devices-homey.constants.ts
+++ b/apps/backend/src/plugins/devices-homey/devices-homey.constants.ts
@@ -41,6 +41,10 @@ export const HOMEY_RECONNECT_JITTER_RATIO = 0.2;
 
 export const HOMEY_CLOUD_AUTHORIZE_URL = 'https://api.athom.com/oauth2/authorise';
 
+export const HOMEY_CLOUD_API_URL = 'https://api.athom.com';
+
+export const HOMEY_CLOUD_TOKEN_URL = `${HOMEY_CLOUD_API_URL}/oauth2/token`;
+
 export const HOMEY_CLOUD_CALLBACK_PATH = '/api/v1/plugins/devices-homey/oauth/callback';
 
 export const HOMEY_CLOUD_CLIENT_ID_ENV = 'FB_HOMEY_CLOUD_CLIENT_ID';

--- a/apps/backend/src/plugins/devices-homey/devices-homey.constants.ts
+++ b/apps/backend/src/plugins/devices-homey/devices-homey.constants.ts
@@ -45,6 +45,8 @@ export const HOMEY_CLOUD_API_URL = 'https://api.athom.com';
 
 export const HOMEY_CLOUD_TOKEN_URL = `${HOMEY_CLOUD_API_URL}/oauth2/token`;
 
+export const HOMEY_CLOUD_HOMEY_HOST_SUFFIX = '.connect.athom.com';
+
 export const HOMEY_CLOUD_CALLBACK_PATH = '/api/v1/plugins/devices-homey/oauth/callback';
 
 export const HOMEY_CLOUD_CLIENT_ID_ENV = 'FB_HOMEY_CLOUD_CLIENT_ID';

--- a/apps/backend/src/plugins/devices-homey/devices-homey.plugin.ts
+++ b/apps/backend/src/plugins/devices-homey/devices-homey.plugin.ts
@@ -64,6 +64,7 @@ import { HomeyConfigModel } from './models/config.model';
 import { HomeyDevicePlatform } from './platforms/homey-device.platform';
 import { HomeyAdoptionLockService } from './services/homey-adoption-lock.service';
 import { HomeyCloudAuthorizationStateService } from './services/homey-cloud-authorization-state.service';
+import { HomeyCloudAuthorizationService } from './services/homey-cloud-authorization.service';
 import { HomeyCloudClientConfigService } from './services/homey-cloud-client-config.service';
 import { HomeyCloudGrantMutationService } from './services/homey-cloud-grant-mutation.service';
 import { HomeyConfigValidatorService } from './services/homey-config-validator.service';
@@ -103,6 +104,7 @@ import { HomeyService } from './services/homey.service';
 		HomeyCloudClientConfigService,
 		HomeyCloudAuthorizationStateService,
 		HomeyCloudGrantMutationService,
+		HomeyCloudAuthorizationService,
 		HomeySdkClientFactoryService,
 		HomeyLocalConnectorFactory,
 		{
@@ -137,6 +139,7 @@ import { HomeyService } from './services/homey.service';
 		HomeyDeviceAdoptionService,
 		HomeySynchronizerService,
 		HomeyService,
+		HomeyCloudAuthorizationService,
 	],
 })
 export class DevicesHomeyPlugin implements OnModuleInit {

--- a/apps/backend/src/plugins/devices-homey/errors/homey-cloud-authorization.error.ts
+++ b/apps/backend/src/plugins/devices-homey/errors/homey-cloud-authorization.error.ts
@@ -18,3 +18,47 @@ export class HomeyCloudAuthorizationCapacityError extends Error {
 		this.name = 'HomeyCloudAuthorizationCapacityError';
 	}
 }
+
+export enum HomeyCloudProviderErrorCategory {
+	INVALID_GRANT = 'invalid_grant',
+	INVALID_TOKEN = 'invalid_token',
+	NO_ELIGIBLE_HOMEYS = 'no_eligible_homeys',
+	PROTOCOL = 'protocol',
+	TIMEOUT = 'timeout',
+	UNAVAILABLE = 'unavailable',
+}
+
+export enum HomeyCloudProviderOperation {
+	EXCHANGE_CODE = 'exchange_code',
+	LIST_HOMEYS = 'list_homeys',
+	AUTHENTICATE_HOMEY = 'authenticate_homey',
+}
+
+const RETRYABLE_PROVIDER_CATEGORIES = new Set<HomeyCloudProviderErrorCategory>([
+	HomeyCloudProviderErrorCategory.TIMEOUT,
+	HomeyCloudProviderErrorCategory.UNAVAILABLE,
+]);
+
+/** Sanitized provider failure that never retains a raw SDK error, response, code, or token. */
+export class HomeyCloudProviderError extends Error {
+	readonly category: HomeyCloudProviderErrorCategory;
+	readonly operation: HomeyCloudProviderOperation;
+	readonly retryable: boolean;
+
+	constructor(category: HomeyCloudProviderErrorCategory, operation: HomeyCloudProviderOperation) {
+		super(`Homey Cloud provider operation '${operation}' failed (${category})`);
+
+		this.name = 'HomeyCloudProviderError';
+		this.category = category;
+		this.operation = operation;
+		this.retryable = RETRYABLE_PROVIDER_CATEGORIES.has(category);
+	}
+}
+
+export class HomeyCloudSelectionError extends Error {
+	constructor() {
+		super('The selected Homey is not available in this authorization transaction');
+
+		this.name = 'HomeyCloudSelectionError';
+	}
+}

--- a/apps/backend/src/plugins/devices-homey/errors/homey-cloud-authorization.error.ts
+++ b/apps/backend/src/plugins/devices-homey/errors/homey-cloud-authorization.error.ts
@@ -24,6 +24,7 @@ export enum HomeyCloudProviderErrorCategory {
 	INVALID_TOKEN = 'invalid_token',
 	NO_ELIGIBLE_HOMEYS = 'no_eligible_homeys',
 	PROTOCOL = 'protocol',
+	RATE_LIMITED = 'rate_limited',
 	TIMEOUT = 'timeout',
 	UNAVAILABLE = 'unavailable',
 }
@@ -37,6 +38,7 @@ export enum HomeyCloudProviderOperation {
 const RETRYABLE_PROVIDER_CATEGORIES = new Set<HomeyCloudProviderErrorCategory>([
 	HomeyCloudProviderErrorCategory.TIMEOUT,
 	HomeyCloudProviderErrorCategory.UNAVAILABLE,
+	HomeyCloudProviderErrorCategory.RATE_LIMITED,
 ]);
 
 /** Sanitized provider failure that never retains a raw SDK error, response, code, or token. */

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization-state.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization-state.service.spec.ts
@@ -45,6 +45,7 @@ describe('HomeyCloudAuthorizationStateService', () => {
 
 				return url.toString();
 			}),
+			createCloudProviderClient: jest.fn(),
 		};
 
 		service = new HomeyCloudAuthorizationStateService(

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.spec.ts
@@ -141,7 +141,8 @@ describe('HomeyCloudAuthorizationService', () => {
 			homey: { id: 'homey-one', name: 'Home' },
 			grant: activeGrant,
 		});
-		expect(candidateClient.authenticateHomey.mock.calls).toEqual([['homey-one']]);
+		expect(candidateClient.authenticateHomey.mock.calls[0]?.[0]).toBe('homey-one');
+		expect(candidateClient.authenticateHomey.mock.calls[0]?.[1]).toBeInstanceOf(AbortSignal);
 		expect(grantMutations.activateCandidate).toHaveBeenCalledWith(
 			exchange.transactionId,
 			exchange.initiatingUserId,
@@ -180,7 +181,17 @@ describe('HomeyCloudAuthorizationService', () => {
 	});
 
 	it('retains the candidate after a bounded retryable provider timeout', async () => {
-		candidateClient.getHomeys.mockReturnValue(new Promise(() => undefined));
+		let providerSignal: AbortSignal | null = null;
+
+		candidateClient.getHomeys.mockImplementation((signal) => {
+			providerSignal = signal;
+
+			return new Promise((_resolve, reject) => {
+				signal.addEventListener('abort', () => reject(Object.assign(new Error('aborted'), { code: 'ABORTERROR' })), {
+					once: true,
+				});
+			});
+		});
 		const result = service.listCandidateHomeys(exchange.transactionId, exchange.initiatingUserId);
 		const expectation = expect(result).rejects.toMatchObject({
 			category: HomeyCloudProviderErrorCategory.TIMEOUT,
@@ -190,6 +201,8 @@ describe('HomeyCloudAuthorizationService', () => {
 		await jest.advanceTimersByTimeAsync(HOMEY_CLOUD_PROVIDER_TIMEOUT_MS);
 
 		await expectation;
+		expect(providerSignal).not.toBeNull();
+		expect((providerSignal as unknown as AbortSignal).aborted).toBe(true);
 		expect(grantMutations.cancelCandidate).not.toHaveBeenCalled();
 	});
 
@@ -246,7 +259,8 @@ describe('HomeyCloudAuthorizationService', () => {
 		await expect(service.selectHomey(exchange.transactionId, exchange.initiatingUserId, 'homey-one')).rejects.toThrow(
 			HomeyCloudGrantConflictError,
 		);
-		expect(candidateClient.authenticateHomey.mock.calls).toEqual([['homey-one']]);
+		expect(candidateClient.authenticateHomey.mock.calls[0]?.[0]).toBe('homey-one');
+		expect(candidateClient.authenticateHomey.mock.calls[0]?.[1]).toBeInstanceOf(AbortSignal);
 		expect(grantMutations.cancelCandidate).not.toHaveBeenCalled();
 	});
 

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.spec.ts
@@ -229,7 +229,7 @@ describe('HomeyCloudAuthorizationService', () => {
 		expect(grantMutations.cancelCandidate).not.toHaveBeenCalled();
 	});
 
-	it.each(['EAI_AGAIN', 'ENOTFOUND'])(
+	it.each(['EAI_AGAIN', 'ENOTFOUND', 'UND_ERR_SOCKET'])(
 		'retains the candidate when native fetch wraps network error %s',
 		async (code) => {
 			candidateClient.getHomeys.mockRejectedValue(

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.spec.ts
@@ -243,8 +243,8 @@ describe('HomeyCloudAuthorizationService', () => {
 		expect(grantMutations.cancelCandidate).not.toHaveBeenCalled();
 	});
 
-	it.each(['EAI_AGAIN', 'ENOTFOUND', 'UND_ERR_SOCKET'])(
-		'retains the candidate when native fetch wraps network error %s',
+	it.each(['EAI_AGAIN', 'ENOTFOUND', 'ERR_STREAM_PREMATURE_CLOSE', 'UND_ERR_SOCKET'])(
+		'retains the candidate when the provider wraps transport error %s',
 		async (code) => {
 			candidateClient.getHomeys.mockRejectedValue(
 				new TypeError('fetch failed', {

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.spec.ts
@@ -154,6 +154,7 @@ describe('HomeyCloudAuthorizationService', () => {
 		});
 		expect(candidateClient.authenticateHomey.mock.calls[0]?.[0]).toBe('homey-one');
 		expect(candidateClient.authenticateHomey.mock.calls[0]?.[1]).toBeInstanceOf(AbortSignal);
+		expect(candidateClient.authenticateHomey.mock.calls[0]?.[2]).toBe(true);
 		expect(grantMutations.activateCandidate).toHaveBeenCalledWith(
 			exchange.transactionId,
 			exchange.initiatingUserId,
@@ -228,19 +229,24 @@ describe('HomeyCloudAuthorizationService', () => {
 		expect(grantMutations.cancelCandidate).not.toHaveBeenCalled();
 	});
 
-	it('retains the candidate when native fetch wraps a transient network error', async () => {
-		candidateClient.getHomeys.mockRejectedValue(
-			new TypeError('fetch failed', {
-				cause: Object.assign(new Error('private network failure'), { code: 'ENOTFOUND' }),
-			}),
-		);
+	it.each(['EAI_AGAIN', 'ENOTFOUND'])(
+		'retains the candidate when native fetch wraps network error %s',
+		async (code) => {
+			candidateClient.getHomeys.mockRejectedValue(
+				new TypeError('fetch failed', {
+					cause: Object.assign(new Error('private network failure'), { code }),
+				}),
+			);
 
-		await expect(service.listCandidateHomeys(exchange.transactionId, exchange.initiatingUserId)).rejects.toMatchObject({
-			category: HomeyCloudProviderErrorCategory.UNAVAILABLE,
-			retryable: true,
-		});
-		expect(grantMutations.cancelCandidate).not.toHaveBeenCalled();
-	});
+			await expect(
+				service.listCandidateHomeys(exchange.transactionId, exchange.initiatingUserId),
+			).rejects.toMatchObject({
+				category: HomeyCloudProviderErrorCategory.UNAVAILABLE,
+				retryable: true,
+			});
+			expect(grantMutations.cancelCandidate).not.toHaveBeenCalled();
+		},
+	);
 
 	it('retains the candidate when Homey rate-limits listing or selection', async () => {
 		candidateClient.getHomeys.mockRejectedValue(
@@ -297,6 +303,7 @@ describe('HomeyCloudAuthorizationService', () => {
 		);
 		expect(candidateClient.authenticateHomey.mock.calls[0]?.[0]).toBe('homey-one');
 		expect(candidateClient.authenticateHomey.mock.calls[0]?.[1]).toBeInstanceOf(AbortSignal);
+		expect(candidateClient.authenticateHomey.mock.calls[0]?.[2]).toBe(false);
 		expect(grantMutations.cancelCandidate).not.toHaveBeenCalled();
 	});
 

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.spec.ts
@@ -135,6 +135,17 @@ describe('HomeyCloudAuthorizationService', () => {
 		expect(grantMutations.activateCandidate).not.toHaveBeenCalled();
 	});
 
+	it('removes Unicode controls from names and rejects identifiers containing them', async () => {
+		candidateClient.getHomeys.mockResolvedValue([
+			homey('homey-one', 'Office\u0085\u009bName'),
+			homey('homey\u0085two', 'Unsafe identifier'),
+		]);
+
+		await expect(service.listCandidateHomeys(exchange.transactionId, exchange.initiatingUserId)).resolves.toEqual([
+			{ id: 'homey-one', name: 'Office Name' },
+		]);
+	});
+
 	it('auto-selects the only eligible Homey after authenticating it', async () => {
 		await expect(service.exchangeAuthorizationCode(exchange)).resolves.toEqual({
 			status: 'activated',

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.spec.ts
@@ -163,6 +163,19 @@ describe('HomeyCloudAuthorizationService', () => {
 		);
 	});
 
+	it('clears the candidate when automatic authentication fails terminally', async () => {
+		candidateClient.authenticateHomey.mockRejectedValue(
+			Object.assign(new Error('private invalid-token response'), { statusCode: 401 }),
+		);
+
+		await expect(service.exchangeAuthorizationCode(exchange)).rejects.toMatchObject({
+			category: HomeyCloudProviderErrorCategory.INVALID_TOKEN,
+			retryable: false,
+		});
+		expect(grantMutations.cancelCandidate).toHaveBeenCalledWith(exchange.transactionId, exchange.initiatingUserId);
+		expect(grantMutations.activateCandidate).not.toHaveBeenCalled();
+	});
+
 	it('does not auto-select when the refreshed inventory is no longer a singleton', async () => {
 		candidateClient.getHomeys
 			.mockResolvedValueOnce([homey('homey-one', 'Home')])

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.spec.ts
@@ -193,6 +193,30 @@ describe('HomeyCloudAuthorizationService', () => {
 		expect(grantMutations.cancelCandidate).not.toHaveBeenCalled();
 	});
 
+	it('retains the candidate when Homey rate-limits listing or selection', async () => {
+		candidateClient.getHomeys.mockRejectedValue(
+			Object.assign(new Error('private rate-limit response'), { statusCode: 429 }),
+		);
+
+		await expect(service.listCandidateHomeys(exchange.transactionId, exchange.initiatingUserId)).rejects.toMatchObject({
+			category: HomeyCloudProviderErrorCategory.RATE_LIMITED,
+			retryable: true,
+		});
+
+		candidateClient.getHomeys.mockResolvedValue([homey('homey-one', 'Home')]);
+		candidateClient.authenticateHomey.mockRejectedValue(
+			Object.assign(new Error('private rate-limit response'), { statusCode: 429 }),
+		);
+
+		await expect(
+			service.selectHomey(exchange.transactionId, exchange.initiatingUserId, 'homey-one'),
+		).rejects.toMatchObject({
+			category: HomeyCloudProviderErrorCategory.RATE_LIMITED,
+			retryable: true,
+		});
+		expect(grantMutations.cancelCandidate).not.toHaveBeenCalled();
+	});
+
 	it('maps raw exchange failures without retaining their private response', async () => {
 		const privateValue = 'private-code-or-token';
 		exchangeClient.exchangeAuthorizationCode.mockRejectedValue(

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.spec.ts
@@ -139,6 +139,7 @@ describe('HomeyCloudAuthorizationService', () => {
 		candidateClient.getHomeys.mockResolvedValue([
 			homey('homey-one', 'Office\u0085\u009bName'),
 			homey('homey\u0085two', 'Unsafe identifier'),
+			homey('homey\u2028three', 'Separator identifier'),
 		]);
 
 		await expect(service.listCandidateHomeys(exchange.transactionId, exchange.initiatingUserId)).resolves.toEqual([

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.spec.ts
@@ -1,0 +1,266 @@
+import {
+	HomeyCloudProviderClient,
+	HomeyCloudProviderHomey,
+	HomeySdkClientFactoryService,
+} from '../connectors/homey-sdk.client';
+import { HOMEY_CLOUD_PENDING_GRANT_TTL_MS, HOMEY_CLOUD_PROVIDER_TIMEOUT_MS } from '../devices-homey.constants';
+import {
+	HomeyCloudProviderError,
+	HomeyCloudProviderErrorCategory,
+	HomeyCloudSelectionError,
+} from '../errors/homey-cloud-authorization.error';
+import { HomeyCloudGrantConflictError } from '../errors/homey-cloud-grant.error';
+
+import { HomeyCloudAuthorizationService } from './homey-cloud-authorization.service';
+import { HomeyCloudClientConfigService } from './homey-cloud-client-config.service';
+import {
+	HomeyCloudActiveGrantReference,
+	HomeyCloudCandidateCredentials,
+	HomeyCloudGrantMutationService,
+} from './homey-cloud-grant-mutation.service';
+
+describe('HomeyCloudAuthorizationService', () => {
+	const now = Date.parse('2026-08-29T08:00:00.000Z');
+	const configuration = {
+		clientId: 'deployment-client-id',
+		clientSecret: 'deployment-client-secret',
+		redirectUrl: 'https://panel.example.com/api/v1/plugins/devices-homey/oauth/callback',
+	};
+	const exchange = {
+		activeGrantGeneration: 4,
+		authorityGeneration: 2,
+		configurationGeneration: 3,
+		initiatingUserId: '11111111-1111-4111-8111-111111111111',
+		transactionId: 'transaction-one',
+		redirectUrl: configuration.redirectUrl,
+		code: 'authorization-code',
+	};
+	const providerToken = {
+		token_type: 'Bearer',
+		access_token: 'candidate-access-token',
+		refresh_token: 'candidate-refresh-token',
+		expires_in: 3600,
+		grant_type: 'authorization_code',
+	};
+	const persistedToken = {
+		tokenType: 'bearer',
+		accessToken: 'candidate-access-token',
+		refreshToken: 'candidate-refresh-token',
+		expiresIn: 3600,
+		grantType: 'authorization_code',
+		issuedAt: now,
+	};
+	const activeGrant: HomeyCloudActiveGrantReference = {
+		grantIdentifier: 'active-grant',
+		activatedById: exchange.initiatingUserId,
+		authorityGeneration: exchange.authorityGeneration,
+		generation: 5,
+		configurationGeneration: exchange.configurationGeneration,
+		selectedHomeyId: 'homey-one',
+	};
+	let exchangeClient: jest.Mocked<HomeyCloudProviderClient>;
+	let candidateClient: jest.Mocked<HomeyCloudProviderClient>;
+	let sdkClientFactory: jest.Mocked<Pick<HomeySdkClientFactoryService, 'createCloudProviderClient'>>;
+	let grantMutations: jest.Mocked<
+		Pick<
+			HomeyCloudGrantMutationService,
+			| 'activateCandidate'
+			| 'cancelCandidate'
+			| 'loadCandidateCredentials'
+			| 'stageCandidate'
+			| 'validateAuthorizationContext'
+		>
+	>;
+	let service: HomeyCloudAuthorizationService;
+
+	beforeEach(() => {
+		jest.useFakeTimers();
+		jest.setSystemTime(now);
+		exchangeClient = providerClient();
+		candidateClient = providerClient();
+		exchangeClient.exchangeAuthorizationCode.mockResolvedValue(providerToken);
+		candidateClient.getHomeys.mockResolvedValue([homey('homey-one', 'Home')]);
+		sdkClientFactory = {
+			createCloudProviderClient: jest.fn((options) => (options.token ? candidateClient : exchangeClient)),
+		};
+		grantMutations = {
+			validateAuthorizationContext: jest.fn().mockResolvedValue(undefined),
+			stageCandidate: jest.fn().mockResolvedValue({ expiresAt: now + HOMEY_CLOUD_PENDING_GRANT_TTL_MS }),
+			loadCandidateCredentials: jest.fn().mockImplementation(() => Promise.resolve(candidate())),
+			cancelCandidate: jest.fn().mockResolvedValue(true),
+			activateCandidate: jest.fn().mockResolvedValue(activeGrant),
+		};
+		service = new HomeyCloudAuthorizationService(
+			{ getConfiguration: jest.fn(() => configuration) } as unknown as HomeyCloudClientConfigService,
+			sdkClientFactory as unknown as HomeySdkClientFactoryService,
+			grantMutations as unknown as HomeyCloudGrantMutationService,
+		);
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it('stages exchanged tokens and returns only bounded eligible choices for multi-Homey accounts', async () => {
+		candidateClient.getHomeys.mockResolvedValue([
+			homey('homey-two', '  Upstairs\nHomey  '),
+			homey('unsupported', 'Unsupported', { apiVersion: 4 }),
+			homey('homey-one', 'Downstairs'),
+		]);
+
+		await expect(service.exchangeAuthorizationCode(exchange)).resolves.toEqual({
+			status: 'selection_required',
+			transactionId: exchange.transactionId,
+			expiresAt: new Date(now + HOMEY_CLOUD_PENDING_GRANT_TTL_MS),
+			homeys: [
+				{ id: 'homey-one', name: 'Downstairs' },
+				{ id: 'homey-two', name: 'Upstairs Homey' },
+			],
+		});
+		expect(grantMutations.validateAuthorizationContext).toHaveBeenCalledWith(exchange);
+		expect(grantMutations.stageCandidate).toHaveBeenCalledWith({
+			activeGrantGeneration: exchange.activeGrantGeneration,
+			authorityGeneration: exchange.authorityGeneration,
+			configurationGeneration: exchange.configurationGeneration,
+			initiatingUserId: exchange.initiatingUserId,
+			redirectUrl: exchange.redirectUrl,
+			transactionId: exchange.transactionId,
+			expiresAt: now + HOMEY_CLOUD_PENDING_GRANT_TTL_MS,
+			token: persistedToken,
+		});
+		expect(sdkClientFactory.createCloudProviderClient).toHaveBeenLastCalledWith({
+			...configuration,
+			token: persistedToken,
+		});
+		expect(grantMutations.activateCandidate).not.toHaveBeenCalled();
+	});
+
+	it('auto-selects the only eligible Homey after authenticating it', async () => {
+		await expect(service.exchangeAuthorizationCode(exchange)).resolves.toEqual({
+			status: 'activated',
+			homey: { id: 'homey-one', name: 'Home' },
+			grant: activeGrant,
+		});
+		expect(candidateClient.authenticateHomey.mock.calls).toEqual([['homey-one']]);
+		expect(grantMutations.activateCandidate).toHaveBeenCalledWith(
+			exchange.transactionId,
+			exchange.initiatingUserId,
+			'homey-one',
+		);
+	});
+
+	it('clears a candidate when no eligible Homey is available', async () => {
+		candidateClient.getHomeys.mockResolvedValue([homey('unsupported', 'Unsupported', { platform: 'unknown' })]);
+
+		await expect(service.exchangeAuthorizationCode(exchange)).rejects.toMatchObject({
+			category: HomeyCloudProviderErrorCategory.NO_ELIGIBLE_HOMEYS,
+		});
+		expect(grantMutations.cancelCandidate).toHaveBeenCalledWith(exchange.transactionId, exchange.initiatingUserId);
+	});
+
+	it('requires an exact transaction-bound selection without clearing a valid candidate', async () => {
+		await expect(
+			service.selectHomey(exchange.transactionId, exchange.initiatingUserId, 'another-homey'),
+		).rejects.toThrow(HomeyCloudSelectionError);
+		expect(candidateClient.authenticateHomey.mock.calls).toHaveLength(0);
+		expect(grantMutations.activateCandidate).not.toHaveBeenCalled();
+		expect(grantMutations.cancelCandidate).not.toHaveBeenCalled();
+	});
+
+	it('clears only the exact candidate after an invalid token response', async () => {
+		candidateClient.getHomeys.mockRejectedValue(
+			Object.assign(new Error('private provider response'), { statusCode: 401 }),
+		);
+
+		await expect(service.listCandidateHomeys(exchange.transactionId, exchange.initiatingUserId)).rejects.toMatchObject({
+			category: HomeyCloudProviderErrorCategory.INVALID_TOKEN,
+			retryable: false,
+		});
+		expect(grantMutations.cancelCandidate).toHaveBeenCalledWith(exchange.transactionId, exchange.initiatingUserId);
+	});
+
+	it('retains the candidate after a bounded retryable provider timeout', async () => {
+		candidateClient.getHomeys.mockReturnValue(new Promise(() => undefined));
+		const result = service.listCandidateHomeys(exchange.transactionId, exchange.initiatingUserId);
+		const expectation = expect(result).rejects.toMatchObject({
+			category: HomeyCloudProviderErrorCategory.TIMEOUT,
+			retryable: true,
+		});
+
+		await jest.advanceTimersByTimeAsync(HOMEY_CLOUD_PROVIDER_TIMEOUT_MS);
+
+		await expectation;
+		expect(grantMutations.cancelCandidate).not.toHaveBeenCalled();
+	});
+
+	it('maps raw exchange failures without retaining their private response', async () => {
+		const privateValue = 'private-code-or-token';
+		exchangeClient.exchangeAuthorizationCode.mockRejectedValue(
+			Object.assign(new Error(privateValue), { statusCode: 400, body: privateValue }),
+		);
+
+		const error = await service.exchangeAuthorizationCode(exchange).catch((caught: unknown) => caught);
+
+		expect(error).toBeInstanceOf(HomeyCloudProviderError);
+		expect(error).toMatchObject({ category: HomeyCloudProviderErrorCategory.INVALID_GRANT });
+		expect(JSON.stringify(error)).not.toContain(privateValue);
+		expect((error as Error).message).not.toContain(privateValue);
+		expect(grantMutations.stageCandidate).not.toHaveBeenCalled();
+	});
+
+	it('rejects stale authorization context before sending the code to Homey', async () => {
+		grantMutations.validateAuthorizationContext.mockRejectedValue(new HomeyCloudGrantConflictError());
+
+		await expect(service.exchangeAuthorizationCode(exchange)).rejects.toThrow(HomeyCloudGrantConflictError);
+		expect(sdkClientFactory.createCloudProviderClient.mock.calls).toHaveLength(0);
+		expect(exchangeClient.exchangeAuthorizationCode.mock.calls).toHaveLength(0);
+	});
+
+	it('does not activate when cancellation or another mutation wins during Homey authentication', async () => {
+		grantMutations.activateCandidate.mockRejectedValue(new HomeyCloudGrantConflictError());
+
+		await expect(service.selectHomey(exchange.transactionId, exchange.initiatingUserId, 'homey-one')).rejects.toThrow(
+			HomeyCloudGrantConflictError,
+		);
+		expect(candidateClient.authenticateHomey.mock.calls).toEqual([['homey-one']]);
+		expect(grantMutations.cancelCandidate).not.toHaveBeenCalled();
+	});
+
+	it('rejects malformed token responses before persistence', async () => {
+		exchangeClient.exchangeAuthorizationCode.mockResolvedValue({
+			...providerToken,
+			token_type: 'mac',
+		});
+
+		await expect(service.exchangeAuthorizationCode(exchange)).rejects.toMatchObject({
+			category: HomeyCloudProviderErrorCategory.PROTOCOL,
+		});
+		expect(grantMutations.stageCandidate).not.toHaveBeenCalled();
+	});
+
+	it('rejects authorization codes containing whitespace before provider access', async () => {
+		await expect(service.exchangeAuthorizationCode({ ...exchange, code: 'private code' })).rejects.toThrow(TypeError);
+		expect(grantMutations.validateAuthorizationContext).not.toHaveBeenCalled();
+		expect(sdkClientFactory.createCloudProviderClient).not.toHaveBeenCalled();
+	});
+
+	function providerClient(): jest.Mocked<HomeyCloudProviderClient> {
+		return {
+			exchangeAuthorizationCode: jest.fn(),
+			getHomeys: jest.fn(),
+			authenticateHomey: jest.fn().mockResolvedValue(undefined),
+		};
+	}
+
+	function homey(id: string, name: string, overrides: Partial<HomeyCloudProviderHomey> = {}): HomeyCloudProviderHomey {
+		return { id, name, apiVersion: 3, platform: 'local', ...overrides };
+	}
+
+	function candidate(): HomeyCloudCandidateCredentials {
+		return {
+			...exchange,
+			token: persistedToken,
+			expiresAt: now + HOMEY_CLOUD_PENDING_GRANT_TTL_MS,
+		};
+	}
+});

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.spec.ts
@@ -150,6 +150,17 @@ describe('HomeyCloudAuthorizationService', () => {
 		);
 	});
 
+	it('does not auto-select when the refreshed inventory is no longer a singleton', async () => {
+		candidateClient.getHomeys
+			.mockResolvedValueOnce([homey('homey-one', 'Home')])
+			.mockResolvedValueOnce([homey('homey-one', 'Home'), homey('homey-two', 'Other Homey')]);
+
+		await expect(service.exchangeAuthorizationCode(exchange)).rejects.toThrow(HomeyCloudSelectionError);
+		expect(candidateClient.authenticateHomey.mock.calls).toHaveLength(0);
+		expect(grantMutations.activateCandidate).not.toHaveBeenCalled();
+		expect(grantMutations.cancelCandidate).not.toHaveBeenCalled();
+	});
+
 	it('clears a candidate when no eligible Homey is available', async () => {
 		candidateClient.getHomeys.mockResolvedValue([homey('unsupported', 'Unsupported', { platform: 'unknown' })]);
 
@@ -203,6 +214,20 @@ describe('HomeyCloudAuthorizationService', () => {
 		await expectation;
 		expect(providerSignal).not.toBeNull();
 		expect((providerSignal as unknown as AbortSignal).aborted).toBe(true);
+		expect(grantMutations.cancelCandidate).not.toHaveBeenCalled();
+	});
+
+	it('retains the candidate when native fetch wraps a transient network error', async () => {
+		candidateClient.getHomeys.mockRejectedValue(
+			new TypeError('fetch failed', {
+				cause: Object.assign(new Error('private network failure'), { code: 'ENOTFOUND' }),
+			}),
+		);
+
+		await expect(service.listCandidateHomeys(exchange.transactionId, exchange.initiatingUserId)).rejects.toMatchObject({
+			category: HomeyCloudProviderErrorCategory.UNAVAILABLE,
+			retryable: true,
+		});
 		expect(grantMutations.cancelCandidate).not.toHaveBeenCalled();
 	});
 

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.ts
@@ -107,7 +107,7 @@ export class HomeyCloudAuthorizationService {
 			}
 
 			if (homeys.length === 1) {
-				return this.selectHomey(input.transactionId, input.initiatingUserId, homeys[0].id);
+				return this.activateSelectedHomey(input.transactionId, input.initiatingUserId, homeys[0].id, true);
 			}
 
 			return {
@@ -153,23 +153,32 @@ export class HomeyCloudAuthorizationService {
 		this.assertHomeyId(selectedHomeyId);
 
 		try {
-			const candidate = await this.grantMutations.loadCandidateCredentials(transactionId, initiatingUserId);
-			const provider = this.createCandidateProvider(candidate);
-			const homeys = await this.getEligibleHomeys(provider);
-			const selectedHomey = homeys.find((homey) => homey.id === selectedHomeyId);
-
-			if (!selectedHomey) throw new HomeyCloudSelectionError();
-
-			await this.runProviderOperation(HomeyCloudProviderOperation.AUTHENTICATE_HOMEY, (signal) =>
-				provider.authenticateHomey(selectedHomey.id, signal),
-			);
-			const grant = await this.grantMutations.activateCandidate(transactionId, initiatingUserId, selectedHomey.id);
-
-			return { status: 'activated', homey: selectedHomey, grant };
+			return await this.activateSelectedHomey(transactionId, initiatingUserId, selectedHomeyId, false);
 		} catch (error) {
 			await this.clearTerminalCandidate(transactionId, initiatingUserId, error);
 			throw error;
 		}
+	}
+
+	private async activateSelectedHomey(
+		transactionId: string,
+		initiatingUserId: string,
+		selectedHomeyId: string,
+		requireSingleton: boolean,
+	): Promise<HomeyCloudActivatedResult> {
+		const candidate = await this.grantMutations.loadCandidateCredentials(transactionId, initiatingUserId);
+		const provider = this.createCandidateProvider(candidate);
+		const homeys = await this.getEligibleHomeys(provider);
+		const selectedHomey = homeys.find((homey) => homey.id === selectedHomeyId);
+
+		if (!selectedHomey || (requireSingleton && homeys.length !== 1)) throw new HomeyCloudSelectionError();
+
+		await this.runProviderOperation(HomeyCloudProviderOperation.AUTHENTICATE_HOMEY, (signal) =>
+			provider.authenticateHomey(selectedHomey.id, signal),
+		);
+		const grant = await this.grantMutations.activateCandidate(transactionId, initiatingUserId, selectedHomey.id);
+
+		return { status: 'activated', homey: selectedHomey, grant };
 	}
 
 	private async loadEligibleHomeys(
@@ -343,10 +352,10 @@ export class HomeyCloudAuthorizationService {
 			return new HomeyCloudProviderError(HomeyCloudProviderErrorCategory.TIMEOUT, operation);
 		}
 
-		const record = typeof error === 'object' && error !== null ? (error as Record<string, unknown>) : {};
-		const statusCode = [record.statusCode, record.status, record.code].find(
-			(value): value is number => typeof value === 'number' && Number.isInteger(value),
-		);
+		const records = this.providerErrorChain(error);
+		const statusCode = records
+			.flatMap((record) => [record.statusCode, record.status, record.code])
+			.find((value): value is number => typeof value === 'number' && Number.isInteger(value));
 
 		if (statusCode === 401 || (operation === HomeyCloudProviderOperation.EXCHANGE_CODE && statusCode === 400)) {
 			return new HomeyCloudProviderError(
@@ -366,16 +375,38 @@ export class HomeyCloudAuthorizationService {
 			return new HomeyCloudProviderError(HomeyCloudProviderErrorCategory.UNAVAILABLE, operation);
 		}
 
-		const code = typeof record.code === 'string' ? record.code.toUpperCase() : '';
+		const codes = records.flatMap((record) =>
+			[record.code, record.name, record.type]
+				.filter((value): value is string => typeof value === 'string')
+				.map((value) => value.toUpperCase()),
+		);
 
-		if (['ABORTERROR', 'ECONNABORTED', 'ETIMEDOUT', 'TIMEOUTERROR'].includes(code)) {
+		if (codes.some((code) => ['ABORTERROR', 'ABORT_ERR', 'ECONNABORTED', 'ETIMEDOUT', 'TIMEOUTERROR'].includes(code))) {
 			return new HomeyCloudProviderError(HomeyCloudProviderErrorCategory.TIMEOUT, operation);
 		}
-		if (['ECONNREFUSED', 'ECONNRESET', 'EHOSTUNREACH', 'ENETUNREACH', 'ENOTFOUND'].includes(code)) {
+		if (
+			codes.some((code) => ['ECONNREFUSED', 'ECONNRESET', 'EHOSTUNREACH', 'ENETUNREACH', 'ENOTFOUND'].includes(code))
+		) {
 			return new HomeyCloudProviderError(HomeyCloudProviderErrorCategory.UNAVAILABLE, operation);
 		}
 
 		return new HomeyCloudProviderError(HomeyCloudProviderErrorCategory.PROTOCOL, operation);
+	}
+
+	private providerErrorChain(error: unknown): readonly Record<string, unknown>[] {
+		const records: Record<string, unknown>[] = [];
+		const seen = new Set<object>();
+		let current = error;
+
+		while (typeof current === 'object' && current !== null && records.length < 5 && !seen.has(current)) {
+			seen.add(current);
+			const record = current as Record<string, unknown>;
+
+			records.push(record);
+			current = record.cause;
+		}
+
+		return records;
 	}
 
 	private async clearTerminalCandidate(transactionId: string, initiatingUserId: string, error: unknown): Promise<void> {

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.ts
@@ -107,7 +107,7 @@ export class HomeyCloudAuthorizationService {
 			}
 
 			if (homeys.length === 1) {
-				return this.activateSelectedHomey(input.transactionId, input.initiatingUserId, homeys[0].id, true);
+				return await this.activateSelectedHomey(input.transactionId, input.initiatingUserId, homeys[0].id, true);
 			}
 
 			return {

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.ts
@@ -79,9 +79,8 @@ export class HomeyCloudAuthorizationService {
 
 		const provider = this.sdkClientFactory.createCloudProviderClient(configuration);
 		const issuedAt = Date.now();
-		const response = await this.runProviderOperation(
-			HomeyCloudProviderOperation.EXCHANGE_CODE,
-			provider.exchangeAuthorizationCode(input.code),
+		const response = await this.runProviderOperation(HomeyCloudProviderOperation.EXCHANGE_CODE, (signal) =>
+			provider.exchangeAuthorizationCode(input.code, signal),
 		);
 		const token = this.normalizeToken(response, issuedAt);
 		const tokenExpiresAt = this.tokenExpiresAt(token);
@@ -161,9 +160,8 @@ export class HomeyCloudAuthorizationService {
 
 			if (!selectedHomey) throw new HomeyCloudSelectionError();
 
-			await this.runProviderOperation(
-				HomeyCloudProviderOperation.AUTHENTICATE_HOMEY,
-				provider.authenticateHomey(selectedHomey.id),
+			await this.runProviderOperation(HomeyCloudProviderOperation.AUTHENTICATE_HOMEY, (signal) =>
+				provider.authenticateHomey(selectedHomey.id, signal),
 			);
 			const grant = await this.grantMutations.activateCandidate(transactionId, initiatingUserId, selectedHomey.id);
 
@@ -195,7 +193,9 @@ export class HomeyCloudAuthorizationService {
 	}
 
 	private async getEligibleHomeys(provider: HomeyCloudProviderClient): Promise<readonly HomeyCloudChoice[]> {
-		const response = await this.runProviderOperation(HomeyCloudProviderOperation.LIST_HOMEYS, provider.getHomeys());
+		const response = await this.runProviderOperation(HomeyCloudProviderOperation.LIST_HOMEYS, (signal) =>
+			provider.getHomeys(signal),
+		);
 		const choices: HomeyCloudChoice[] = [];
 		const identifiers = new Set<string>();
 
@@ -311,14 +311,22 @@ export class HomeyCloudAuthorizationService {
 		return typeof value === 'string' && value.length > 0 && value.length <= HOMEY_CLOUD_MAX_TOKEN_LENGTH ? value : null;
 	}
 
-	private async runProviderOperation<T>(operation: HomeyCloudProviderOperation, promise: Promise<T>): Promise<T> {
+	private async runProviderOperation<T>(
+		operation: HomeyCloudProviderOperation,
+		execute: (signal: AbortSignal) => Promise<T>,
+	): Promise<T> {
 		let timeout: NodeJS.Timeout | null = null;
+		const controller = new AbortController();
+		const timeoutError = new ProviderTimeoutError();
 
 		try {
 			return await Promise.race([
-				promise,
+				execute(controller.signal),
 				new Promise<never>((_resolve, reject) => {
-					timeout = setTimeout(() => reject(new ProviderTimeoutError()), HOMEY_CLOUD_PROVIDER_TIMEOUT_MS);
+					timeout = setTimeout(() => {
+						controller.abort(timeoutError);
+						reject(timeoutError);
+					}, HOMEY_CLOUD_PROVIDER_TIMEOUT_MS);
 					timeout.unref();
 				}),
 			]);

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.ts
@@ -32,6 +32,7 @@ import {
 
 const SUPPORTED_API_VERSIONS = new Set([1, 2, 3]);
 const SUPPORTED_PLATFORMS = new Set(['cloud', 'local']);
+const UNICODE_CONTROL_PATTERN = /[\p{Cc}\p{Cf}]/u;
 
 class ProviderTimeoutError extends Error {}
 
@@ -424,11 +425,7 @@ export class HomeyCloudAuthorizationService {
 			typeof input.code !== 'string' ||
 			input.code.length === 0 ||
 			input.code.length > HOMEY_CLOUD_MAX_AUTHORIZATION_CODE_LENGTH ||
-			[...input.code].some((character) => {
-				const codePoint = character.codePointAt(0) ?? 0;
-
-				return codePoint <= 32 || codePoint === 127;
-			})
+			[...input.code].some((character) => /\s/u.test(character) || this.isControlCharacter(character))
 		) {
 			throw new TypeError('Homey Cloud authorization code is invalid');
 		}
@@ -447,7 +444,7 @@ export class HomeyCloudAuthorizationService {
 	}
 
 	private assertIdentifier(value: string): void {
-		if (typeof value !== 'string' || value.trim().length === 0) {
+		if (typeof value !== 'string' || value.trim().length === 0 || this.containsControlCharacter(value)) {
 			throw new TypeError('Homey Cloud authorization identifier is invalid');
 		}
 	}
@@ -464,8 +461,6 @@ export class HomeyCloudAuthorizationService {
 	}
 
 	private isControlCharacter(character: string): boolean {
-		const codePoint = character.codePointAt(0) ?? 0;
-
-		return codePoint <= 31 || codePoint === 127;
+		return UNICODE_CONTROL_PATTERN.test(character);
 	}
 }

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.ts
@@ -5,10 +5,10 @@ import {
 	HomeyCloudProviderTokenResponse,
 	HomeySdkClientFactoryService,
 	isEligibleHomeyCloudProviderHomey,
+	isSafeHomeyCloudProviderHomeyId,
 } from '../connectors/homey-sdk.client';
 import {
 	HOMEY_CLOUD_MAX_AUTHORIZATION_CODE_LENGTH,
-	HOMEY_CLOUD_MAX_HOMEY_ID_LENGTH,
 	HOMEY_CLOUD_MAX_HOMEY_NAME_LENGTH,
 	HOMEY_CLOUD_MAX_TOKEN_LENGTH,
 	HOMEY_CLOUD_PENDING_GRANT_TTL_MS,
@@ -435,11 +435,7 @@ export class HomeyCloudAuthorizationService {
 	private assertHomeyId(value: string): void {
 		this.assertIdentifier(value);
 
-		if (
-			value !== value.trim() ||
-			value.length > HOMEY_CLOUD_MAX_HOMEY_ID_LENGTH ||
-			this.containsControlCharacter(value)
-		) {
+		if (!isSafeHomeyCloudProviderHomeyId(value)) {
 			throw new TypeError('Homey Cloud Homey identifier is invalid');
 		}
 	}

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.ts
@@ -1,0 +1,429 @@
+import { Injectable } from '@nestjs/common';
+
+import {
+	HomeyCloudProviderClient,
+	HomeyCloudProviderTokenResponse,
+	HomeySdkClientFactoryService,
+} from '../connectors/homey-sdk.client';
+import {
+	HOMEY_CLOUD_MAX_AUTHORIZATION_CODE_LENGTH,
+	HOMEY_CLOUD_MAX_HOMEY_ID_LENGTH,
+	HOMEY_CLOUD_MAX_HOMEY_NAME_LENGTH,
+	HOMEY_CLOUD_MAX_TOKEN_LENGTH,
+	HOMEY_CLOUD_PENDING_GRANT_TTL_MS,
+	HOMEY_CLOUD_PROVIDER_TIMEOUT_MS,
+} from '../devices-homey.constants';
+import {
+	HomeyCloudProviderError,
+	HomeyCloudProviderErrorCategory,
+	HomeyCloudProviderOperation,
+	HomeyCloudSelectionError,
+} from '../errors/homey-cloud-authorization.error';
+import { HomeyCloudGrantConflictError } from '../errors/homey-cloud-grant.error';
+
+import { HomeyCloudClientConfigService } from './homey-cloud-client-config.service';
+import {
+	HomeyCloudActiveGrantReference,
+	HomeyCloudAuthorizationContext,
+	HomeyCloudCandidateCredentials,
+	HomeyCloudGrantMutationService,
+	HomeyCloudTokenMaterial,
+} from './homey-cloud-grant-mutation.service';
+
+const SUPPORTED_API_VERSIONS = new Set([1, 2, 3]);
+const SUPPORTED_PLATFORMS = new Set(['cloud', 'local']);
+
+class ProviderTimeoutError extends Error {}
+
+export interface HomeyCloudAuthorizationExchange extends HomeyCloudAuthorizationContext {
+	readonly code: string;
+	readonly redirectUrl: string;
+	readonly transactionId: string;
+}
+
+export interface HomeyCloudChoice {
+	readonly id: string;
+	readonly name: string;
+}
+
+export interface HomeyCloudSelectionRequiredResult {
+	readonly expiresAt: Date;
+	readonly homeys: readonly HomeyCloudChoice[];
+	readonly status: 'selection_required';
+	readonly transactionId: string;
+}
+
+export interface HomeyCloudActivatedResult {
+	readonly grant: HomeyCloudActiveGrantReference;
+	readonly homey: HomeyCloudChoice;
+	readonly status: 'activated';
+}
+
+export type HomeyCloudAuthorizationResult = HomeyCloudActivatedResult | HomeyCloudSelectionRequiredResult;
+
+@Injectable()
+export class HomeyCloudAuthorizationService {
+	constructor(
+		private readonly clientConfig: HomeyCloudClientConfigService,
+		private readonly sdkClientFactory: HomeySdkClientFactoryService,
+		private readonly grantMutations: HomeyCloudGrantMutationService,
+	) {}
+
+	async exchangeAuthorizationCode(input: HomeyCloudAuthorizationExchange): Promise<HomeyCloudAuthorizationResult> {
+		this.assertExchange(input);
+		await this.grantMutations.validateAuthorizationContext(input);
+
+		const configuration = this.clientConfig.getConfiguration();
+
+		if (configuration.redirectUrl !== input.redirectUrl) throw new HomeyCloudGrantConflictError();
+
+		const provider = this.sdkClientFactory.createCloudProviderClient(configuration);
+		const issuedAt = Date.now();
+		const response = await this.runProviderOperation(
+			HomeyCloudProviderOperation.EXCHANGE_CODE,
+			provider.exchangeAuthorizationCode(input.code),
+		);
+		const token = this.normalizeToken(response, issuedAt);
+		const tokenExpiresAt = this.tokenExpiresAt(token);
+		const { expiresAt } = await this.grantMutations.stageCandidate({
+			activeGrantGeneration: input.activeGrantGeneration,
+			authorityGeneration: input.authorityGeneration,
+			configurationGeneration: input.configurationGeneration,
+			initiatingUserId: input.initiatingUserId,
+			redirectUrl: input.redirectUrl,
+			transactionId: input.transactionId,
+			expiresAt:
+				tokenExpiresAt === null ? undefined : Math.min(issuedAt + HOMEY_CLOUD_PENDING_GRANT_TTL_MS, tokenExpiresAt),
+			token,
+		});
+
+		try {
+			const homeys = await this.loadEligibleHomeys(input.transactionId, input.initiatingUserId);
+
+			if (homeys.length === 0) {
+				throw new HomeyCloudProviderError(
+					HomeyCloudProviderErrorCategory.NO_ELIGIBLE_HOMEYS,
+					HomeyCloudProviderOperation.LIST_HOMEYS,
+				);
+			}
+
+			if (homeys.length === 1) {
+				return this.selectHomey(input.transactionId, input.initiatingUserId, homeys[0].id);
+			}
+
+			return {
+				status: 'selection_required',
+				transactionId: input.transactionId,
+				expiresAt: new Date(expiresAt),
+				homeys,
+			};
+		} catch (error) {
+			await this.clearTerminalCandidate(input.transactionId, input.initiatingUserId, error);
+			throw error;
+		}
+	}
+
+	async listCandidateHomeys(transactionId: string, initiatingUserId: string): Promise<readonly HomeyCloudChoice[]> {
+		this.assertIdentifier(transactionId);
+		this.assertIdentifier(initiatingUserId);
+
+		try {
+			const homeys = await this.loadEligibleHomeys(transactionId, initiatingUserId);
+
+			if (homeys.length === 0) {
+				throw new HomeyCloudProviderError(
+					HomeyCloudProviderErrorCategory.NO_ELIGIBLE_HOMEYS,
+					HomeyCloudProviderOperation.LIST_HOMEYS,
+				);
+			}
+
+			return homeys;
+		} catch (error) {
+			await this.clearTerminalCandidate(transactionId, initiatingUserId, error);
+			throw error;
+		}
+	}
+
+	async selectHomey(
+		transactionId: string,
+		initiatingUserId: string,
+		selectedHomeyId: string,
+	): Promise<HomeyCloudActivatedResult> {
+		this.assertIdentifier(transactionId);
+		this.assertIdentifier(initiatingUserId);
+		this.assertHomeyId(selectedHomeyId);
+
+		try {
+			const candidate = await this.grantMutations.loadCandidateCredentials(transactionId, initiatingUserId);
+			const provider = this.createCandidateProvider(candidate);
+			const homeys = await this.getEligibleHomeys(provider);
+			const selectedHomey = homeys.find((homey) => homey.id === selectedHomeyId);
+
+			if (!selectedHomey) throw new HomeyCloudSelectionError();
+
+			await this.runProviderOperation(
+				HomeyCloudProviderOperation.AUTHENTICATE_HOMEY,
+				provider.authenticateHomey(selectedHomey.id),
+			);
+			const grant = await this.grantMutations.activateCandidate(transactionId, initiatingUserId, selectedHomey.id);
+
+			return { status: 'activated', homey: selectedHomey, grant };
+		} catch (error) {
+			await this.clearTerminalCandidate(transactionId, initiatingUserId, error);
+			throw error;
+		}
+	}
+
+	private async loadEligibleHomeys(
+		transactionId: string,
+		initiatingUserId: string,
+	): Promise<readonly HomeyCloudChoice[]> {
+		const candidate = await this.grantMutations.loadCandidateCredentials(transactionId, initiatingUserId);
+
+		return this.getEligibleHomeys(this.createCandidateProvider(candidate));
+	}
+
+	private createCandidateProvider(candidate: HomeyCloudCandidateCredentials): HomeyCloudProviderClient {
+		const configuration = this.clientConfig.getConfiguration();
+
+		if (configuration.redirectUrl !== candidate.redirectUrl) throw new HomeyCloudGrantConflictError();
+
+		return this.sdkClientFactory.createCloudProviderClient({
+			...configuration,
+			token: candidate.token,
+		});
+	}
+
+	private async getEligibleHomeys(provider: HomeyCloudProviderClient): Promise<readonly HomeyCloudChoice[]> {
+		const response = await this.runProviderOperation(HomeyCloudProviderOperation.LIST_HOMEYS, provider.getHomeys());
+		const choices: HomeyCloudChoice[] = [];
+		const identifiers = new Set<string>();
+
+		if (!Array.isArray(response)) {
+			throw new HomeyCloudProviderError(
+				HomeyCloudProviderErrorCategory.PROTOCOL,
+				HomeyCloudProviderOperation.LIST_HOMEYS,
+			);
+		}
+
+		for (const homey of response as readonly unknown[]) {
+			const choice = this.normalizeHomey(homey);
+
+			if (!choice) continue;
+			if (identifiers.has(choice.id)) {
+				throw new HomeyCloudProviderError(
+					HomeyCloudProviderErrorCategory.PROTOCOL,
+					HomeyCloudProviderOperation.LIST_HOMEYS,
+				);
+			}
+
+			identifiers.add(choice.id);
+			choices.push(choice);
+		}
+
+		return choices.sort(
+			(left, right) => this.compareStrings(left.name, right.name) || this.compareStrings(left.id, right.id),
+		);
+	}
+
+	private normalizeHomey(homey: unknown): HomeyCloudChoice | null {
+		if (typeof homey !== 'object' || homey === null || Array.isArray(homey)) return null;
+
+		const record = homey as Record<string, unknown>;
+
+		if (
+			!SUPPORTED_API_VERSIONS.has(record.apiVersion as number) ||
+			!SUPPORTED_PLATFORMS.has(record.platform as string) ||
+			typeof record.id !== 'string' ||
+			record.id !== record.id.trim() ||
+			record.id.length === 0 ||
+			record.id.length > HOMEY_CLOUD_MAX_HOMEY_ID_LENGTH ||
+			this.containsControlCharacter(record.id)
+		) {
+			return null;
+		}
+
+		const rawName = typeof record.name === 'string' ? record.name : '';
+		const normalizedName = [...rawName]
+			.map((character) => (this.isControlCharacter(character) ? ' ' : character))
+			.join('')
+			.replace(/\s+/gu, ' ')
+			.trim();
+		const name = [...normalizedName].slice(0, HOMEY_CLOUD_MAX_HOMEY_NAME_LENGTH).join('');
+
+		return { id: record.id, name: name || 'Homey' };
+	}
+
+	private normalizeToken(response: HomeyCloudProviderTokenResponse, issuedAt: number): HomeyCloudTokenMaterial {
+		if (!response || typeof response !== 'object') {
+			throw new HomeyCloudProviderError(
+				HomeyCloudProviderErrorCategory.PROTOCOL,
+				HomeyCloudProviderOperation.EXCHANGE_CODE,
+			);
+		}
+
+		const tokenType = this.boundedString(response.token_type)?.toLowerCase();
+		const accessToken = this.boundedString(response.access_token);
+		const refreshToken = response.refresh_token == null ? null : this.boundedString(response.refresh_token);
+		const grantType = response.grant_type == null ? null : this.boundedString(response.grant_type);
+		const expiresIn = response.expires_in == null ? null : response.expires_in;
+
+		if (
+			tokenType !== 'bearer' ||
+			!accessToken ||
+			(response.refresh_token != null && !refreshToken) ||
+			(response.grant_type != null && !grantType) ||
+			(expiresIn !== null && (!Number.isSafeInteger(expiresIn) || (expiresIn as number) <= 0))
+		) {
+			throw new HomeyCloudProviderError(
+				HomeyCloudProviderErrorCategory.PROTOCOL,
+				HomeyCloudProviderOperation.EXCHANGE_CODE,
+			);
+		}
+
+		return {
+			tokenType,
+			accessToken,
+			refreshToken,
+			expiresIn: expiresIn as number | null,
+			grantType,
+			issuedAt,
+		};
+	}
+
+	private tokenExpiresAt(token: HomeyCloudTokenMaterial): number | null {
+		if (token.expiresIn === null) return null;
+
+		const lifetimeMs = token.expiresIn * 1000;
+		const expiresAt = token.issuedAt + lifetimeMs;
+
+		if (!Number.isSafeInteger(lifetimeMs) || !Number.isSafeInteger(expiresAt) || expiresAt <= Date.now()) {
+			throw new HomeyCloudProviderError(
+				HomeyCloudProviderErrorCategory.INVALID_TOKEN,
+				HomeyCloudProviderOperation.EXCHANGE_CODE,
+			);
+		}
+
+		return expiresAt;
+	}
+
+	private boundedString(value: unknown): string | null {
+		return typeof value === 'string' && value.length > 0 && value.length <= HOMEY_CLOUD_MAX_TOKEN_LENGTH ? value : null;
+	}
+
+	private async runProviderOperation<T>(operation: HomeyCloudProviderOperation, promise: Promise<T>): Promise<T> {
+		let timeout: NodeJS.Timeout | null = null;
+
+		try {
+			return await Promise.race([
+				promise,
+				new Promise<never>((_resolve, reject) => {
+					timeout = setTimeout(() => reject(new ProviderTimeoutError()), HOMEY_CLOUD_PROVIDER_TIMEOUT_MS);
+					timeout.unref();
+				}),
+			]);
+		} catch (error) {
+			throw this.mapProviderError(error, operation);
+		} finally {
+			if (timeout) clearTimeout(timeout);
+		}
+	}
+
+	private mapProviderError(error: unknown, operation: HomeyCloudProviderOperation): HomeyCloudProviderError {
+		if (error instanceof HomeyCloudProviderError) return error;
+		if (error instanceof ProviderTimeoutError) {
+			return new HomeyCloudProviderError(HomeyCloudProviderErrorCategory.TIMEOUT, operation);
+		}
+
+		const record = typeof error === 'object' && error !== null ? (error as Record<string, unknown>) : {};
+		const statusCode = [record.statusCode, record.status, record.code].find(
+			(value): value is number => typeof value === 'number' && Number.isInteger(value),
+		);
+
+		if (statusCode === 401 || (operation === HomeyCloudProviderOperation.EXCHANGE_CODE && statusCode === 400)) {
+			return new HomeyCloudProviderError(
+				operation === HomeyCloudProviderOperation.EXCHANGE_CODE
+					? HomeyCloudProviderErrorCategory.INVALID_GRANT
+					: HomeyCloudProviderErrorCategory.INVALID_TOKEN,
+				operation,
+			);
+		}
+		if (statusCode === 408 || statusCode === 504) {
+			return new HomeyCloudProviderError(HomeyCloudProviderErrorCategory.TIMEOUT, operation);
+		}
+		if (statusCode !== undefined && statusCode >= 500) {
+			return new HomeyCloudProviderError(HomeyCloudProviderErrorCategory.UNAVAILABLE, operation);
+		}
+
+		const code = typeof record.code === 'string' ? record.code.toUpperCase() : '';
+
+		if (['ABORTERROR', 'ECONNABORTED', 'ETIMEDOUT', 'TIMEOUTERROR'].includes(code)) {
+			return new HomeyCloudProviderError(HomeyCloudProviderErrorCategory.TIMEOUT, operation);
+		}
+		if (['ECONNREFUSED', 'ECONNRESET', 'EHOSTUNREACH', 'ENETUNREACH', 'ENOTFOUND'].includes(code)) {
+			return new HomeyCloudProviderError(HomeyCloudProviderErrorCategory.UNAVAILABLE, operation);
+		}
+
+		return new HomeyCloudProviderError(HomeyCloudProviderErrorCategory.PROTOCOL, operation);
+	}
+
+	private async clearTerminalCandidate(transactionId: string, initiatingUserId: string, error: unknown): Promise<void> {
+		if (error instanceof HomeyCloudProviderError && !error.retryable) {
+			await this.grantMutations.cancelCandidate(transactionId, initiatingUserId);
+		}
+	}
+
+	private assertExchange(input: HomeyCloudAuthorizationExchange): void {
+		this.assertIdentifier(input.transactionId);
+		this.assertIdentifier(input.initiatingUserId);
+		this.assertIdentifier(input.redirectUrl);
+
+		if (
+			typeof input.code !== 'string' ||
+			input.code.length === 0 ||
+			input.code.length > HOMEY_CLOUD_MAX_AUTHORIZATION_CODE_LENGTH ||
+			[...input.code].some((character) => {
+				const codePoint = character.codePointAt(0) ?? 0;
+
+				return codePoint <= 32 || codePoint === 127;
+			})
+		) {
+			throw new TypeError('Homey Cloud authorization code is invalid');
+		}
+	}
+
+	private assertHomeyId(value: string): void {
+		this.assertIdentifier(value);
+
+		if (
+			value !== value.trim() ||
+			value.length > HOMEY_CLOUD_MAX_HOMEY_ID_LENGTH ||
+			this.containsControlCharacter(value)
+		) {
+			throw new TypeError('Homey Cloud Homey identifier is invalid');
+		}
+	}
+
+	private assertIdentifier(value: string): void {
+		if (typeof value !== 'string' || value.trim().length === 0) {
+			throw new TypeError('Homey Cloud authorization identifier is invalid');
+		}
+	}
+
+	private containsControlCharacter(value: string): boolean {
+		return [...value].some((character) => this.isControlCharacter(character));
+	}
+
+	private compareStrings(left: string, right: string): number {
+		if (left < right) return -1;
+		if (left > right) return 1;
+
+		return 0;
+	}
+
+	private isControlCharacter(character: string): boolean {
+		const codePoint = character.codePointAt(0) ?? 0;
+
+		return codePoint <= 31 || codePoint === 127;
+	}
+}

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.ts
@@ -32,6 +32,30 @@ import {
 } from './homey-cloud-grant-mutation.service';
 
 const UNICODE_CONTROL_PATTERN = /[\p{Cc}\p{Cf}]/u;
+const PROVIDER_TIMEOUT_CODES = new Set([
+	'ABORTERROR',
+	'ABORT_ERR',
+	'ECONNABORTED',
+	'ETIMEDOUT',
+	'TIMEOUTERROR',
+	'UND_ERR_BODY_TIMEOUT',
+	'UND_ERR_CONNECT_TIMEOUT',
+	'UND_ERR_HEADERS_TIMEOUT',
+]);
+const PROVIDER_UNAVAILABLE_CODES = new Set([
+	'EAI_AGAIN',
+	'ECONNREFUSED',
+	'ECONNRESET',
+	'EHOSTDOWN',
+	'EHOSTUNREACH',
+	'ENETDOWN',
+	'ENETRESET',
+	'ENETUNREACH',
+	'ENOTFOUND',
+	'EPIPE',
+	'ERR_STREAM_PREMATURE_CLOSE',
+	'UND_ERR_SOCKET',
+]);
 
 class ProviderTimeoutError extends Error {}
 
@@ -373,22 +397,10 @@ export class HomeyCloudAuthorizationService {
 				.map((value) => value.toUpperCase()),
 		);
 
-		if (codes.some((code) => ['ABORTERROR', 'ABORT_ERR', 'ECONNABORTED', 'ETIMEDOUT', 'TIMEOUTERROR'].includes(code))) {
+		if (codes.some((code) => PROVIDER_TIMEOUT_CODES.has(code))) {
 			return new HomeyCloudProviderError(HomeyCloudProviderErrorCategory.TIMEOUT, operation);
 		}
-		if (
-			codes.some((code) =>
-				[
-					'EAI_AGAIN',
-					'ECONNREFUSED',
-					'ECONNRESET',
-					'EHOSTUNREACH',
-					'ENETUNREACH',
-					'ENOTFOUND',
-					'UND_ERR_SOCKET',
-				].includes(code),
-			)
-		) {
+		if (codes.some((code) => PROVIDER_UNAVAILABLE_CODES.has(code))) {
 			return new HomeyCloudProviderError(HomeyCloudProviderErrorCategory.UNAVAILABLE, operation);
 		}
 

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.ts
@@ -389,7 +389,15 @@ export class HomeyCloudAuthorizationService {
 		}
 		if (
 			codes.some((code) =>
-				['EAI_AGAIN', 'ECONNREFUSED', 'ECONNRESET', 'EHOSTUNREACH', 'ENETUNREACH', 'ENOTFOUND'].includes(code),
+				[
+					'EAI_AGAIN',
+					'ECONNREFUSED',
+					'ECONNRESET',
+					'EHOSTUNREACH',
+					'ENETUNREACH',
+					'ENOTFOUND',
+					'UND_ERR_SOCKET',
+				].includes(code),
 			)
 		) {
 			return new HomeyCloudProviderError(HomeyCloudProviderErrorCategory.UNAVAILABLE, operation);

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.ts
@@ -4,6 +4,7 @@ import {
 	HomeyCloudProviderClient,
 	HomeyCloudProviderTokenResponse,
 	HomeySdkClientFactoryService,
+	isEligibleHomeyCloudProviderHomey,
 } from '../connectors/homey-sdk.client';
 import {
 	HOMEY_CLOUD_MAX_AUTHORIZATION_CODE_LENGTH,
@@ -30,8 +31,6 @@ import {
 	HomeyCloudTokenMaterial,
 } from './homey-cloud-grant-mutation.service';
 
-const SUPPORTED_API_VERSIONS = new Set([1, 2, 3]);
-const SUPPORTED_PLATFORMS = new Set(['cloud', 'local']);
 const UNICODE_CONTROL_PATTERN = /[\p{Cc}\p{Cf}]/u;
 
 class ProviderTimeoutError extends Error {}
@@ -241,17 +240,7 @@ export class HomeyCloudAuthorizationService {
 
 		const record = homey as Record<string, unknown>;
 
-		if (
-			!SUPPORTED_API_VERSIONS.has(record.apiVersion as number) ||
-			!SUPPORTED_PLATFORMS.has(record.platform as string) ||
-			typeof record.id !== 'string' ||
-			record.id !== record.id.trim() ||
-			record.id.length === 0 ||
-			record.id.length > HOMEY_CLOUD_MAX_HOMEY_ID_LENGTH ||
-			this.containsControlCharacter(record.id)
-		) {
-			return null;
-		}
+		if (!isEligibleHomeyCloudProviderHomey(record)) return null;
 
 		const rawName = typeof record.name === 'string' ? record.name : '';
 		const normalizedName = [...rawName]

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.ts
@@ -351,6 +351,9 @@ export class HomeyCloudAuthorizationService {
 		if (statusCode === 408 || statusCode === 504) {
 			return new HomeyCloudProviderError(HomeyCloudProviderErrorCategory.TIMEOUT, operation);
 		}
+		if (statusCode === 429) {
+			return new HomeyCloudProviderError(HomeyCloudProviderErrorCategory.RATE_LIMITED, operation);
+		}
 		if (statusCode !== undefined && statusCode >= 500) {
 			return new HomeyCloudProviderError(HomeyCloudProviderErrorCategory.UNAVAILABLE, operation);
 		}

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-authorization.service.ts
@@ -175,7 +175,7 @@ export class HomeyCloudAuthorizationService {
 		if (!selectedHomey || (requireSingleton && homeys.length !== 1)) throw new HomeyCloudSelectionError();
 
 		await this.runProviderOperation(HomeyCloudProviderOperation.AUTHENTICATE_HOMEY, (signal) =>
-			provider.authenticateHomey(selectedHomey.id, signal),
+			provider.authenticateHomey(selectedHomey.id, signal, requireSingleton),
 		);
 		const grant = await this.grantMutations.activateCandidate(transactionId, initiatingUserId, selectedHomey.id);
 
@@ -341,6 +341,8 @@ export class HomeyCloudAuthorizationService {
 				}),
 			]);
 		} catch (error) {
+			if (error instanceof HomeyCloudSelectionError) throw error;
+
 			throw this.mapProviderError(error, operation);
 		} finally {
 			if (timeout) clearTimeout(timeout);
@@ -386,7 +388,9 @@ export class HomeyCloudAuthorizationService {
 			return new HomeyCloudProviderError(HomeyCloudProviderErrorCategory.TIMEOUT, operation);
 		}
 		if (
-			codes.some((code) => ['ECONNREFUSED', 'ECONNRESET', 'EHOSTUNREACH', 'ENETUNREACH', 'ENOTFOUND'].includes(code))
+			codes.some((code) =>
+				['EAI_AGAIN', 'ECONNREFUSED', 'ECONNRESET', 'EHOSTUNREACH', 'ENETUNREACH', 'ENOTFOUND'].includes(code),
+			)
 		) {
 			return new HomeyCloudProviderError(HomeyCloudProviderErrorCategory.UNAVAILABLE, operation);
 		}

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-grant-mutation.service.spec.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-grant-mutation.service.spec.ts
@@ -70,6 +70,25 @@ describe('HomeyCloudGrantMutationService', () => {
 		});
 	});
 
+	it('revalidates authority and deployment generations before provider exchange', async () => {
+		const context = await service.getAuthorizationContext(administratorId);
+
+		await expect(service.validateAuthorizationContext(context)).resolves.toBeUndefined();
+
+		configurationFingerprint = 'configuration-two';
+
+		await expect(service.validateAuthorizationContext(context)).rejects.toThrow(HomeyCloudGrantConflictError);
+	});
+
+	it('rejects provider exchange after the initiating administrator loses authority', async () => {
+		const context = await service.getAuthorizationContext(administratorId);
+		await service.invalidateUserAuthority(administratorId, async (manager) => {
+			await manager.getRepository(UserEntity).update({ id: administratorId }, { role: UserRole.USER });
+		});
+
+		await expect(service.validateAuthorizationContext(context)).rejects.toThrow(HomeyCloudGrantAuthorityError);
+	});
+
 	it('keeps the active grant until a generation-matched candidate activates atomically', async () => {
 		const firstContext = await service.getAuthorizationContext(administratorId);
 		await service.stageCandidate(candidateInput(firstContext, 'first-transaction', token('first')));
@@ -86,6 +105,19 @@ describe('HomeyCloudGrantMutationService', () => {
 			...replacement,
 			token: token('replacement'),
 		});
+		await expect(dataSource.getRepository(HomeyCloudPendingGrantEntity).count()).resolves.toBe(0);
+	});
+
+	it('clears a pending candidate before provider access when another activation advances the grant generation', async () => {
+		const context = await service.getAuthorizationContext(administratorId);
+		await service.stageCandidate(candidateInput(context, 'winning-transaction', token('winning')));
+		await service.stageCandidate(candidateInput(context, 'stale-transaction', token('stale')));
+
+		await service.activateCandidate('winning-transaction', administratorId, 'homey-one');
+
+		await expect(service.loadCandidateCredentials('stale-transaction', administratorId)).rejects.toThrow(
+			HomeyCloudGrantConflictError,
+		);
 		await expect(dataSource.getRepository(HomeyCloudPendingGrantEntity).count()).resolves.toBe(0);
 	});
 

--- a/apps/backend/src/plugins/devices-homey/services/homey-cloud-grant-mutation.service.ts
+++ b/apps/backend/src/plugins/devices-homey/services/homey-cloud-grant-mutation.service.ts
@@ -83,6 +83,10 @@ type ActivationOutcome =
 	| { readonly status: 'activated'; readonly grant: HomeyCloudActiveGrantReference }
 	| { readonly status: 'authority' | 'conflict' };
 
+type CandidateCredentialsOutcome =
+	| { readonly status: 'loaded'; readonly candidate: HomeyCloudCandidateCredentials }
+	| { readonly status: 'authority' | 'conflict' };
+
 @Injectable()
 export class HomeyCloudGrantMutationService
 	implements OnApplicationBootstrap, OnModuleDestroy, UserLifecycleMutationParticipant
@@ -125,6 +129,24 @@ export class HomeyCloudGrantMutationService
 					configurationGeneration: state.configurationGeneration,
 					initiatingUserId,
 				};
+			}),
+		);
+	}
+
+	async validateAuthorizationContext(context: HomeyCloudAuthorizationContext): Promise<void> {
+		this.assertAuthorizationContext(context);
+
+		await this.runMutation(() =>
+			this.dataSource.transaction(async (manager) => {
+				await this.requireCurrentAuthority(manager, context.initiatingUserId, context.authorityGeneration);
+				const state = await this.reconcileConfigurationInternal(manager);
+
+				if (
+					state.activeGrantGeneration !== context.activeGrantGeneration ||
+					state.configurationGeneration !== context.configurationGeneration
+				) {
+					throw new HomeyCloudGrantConflictError();
+				}
 			}),
 		);
 	}
@@ -189,18 +211,41 @@ export class HomeyCloudGrantMutationService
 		this.assertIdentifier(transactionId);
 		this.assertIdentifier(initiatingUserId);
 
-		return this.runMutation(() =>
+		const outcome: CandidateCredentialsOutcome = await this.runMutation(() =>
 			this.dataSource.transaction(async (manager) => {
 				const now = Date.now();
-				await this.reconcileConfigurationInternal(manager);
+				const state = await this.reconcileConfigurationInternal(manager);
 				await this.deleteExpiredCandidates(manager, now);
 				const candidate = await this.findCandidateWithCredentials(manager, transactionId, initiatingUserId);
 
-				if (!candidate || candidate.expiresAt <= now) throw new HomeyCloudGrantConflictError();
+				if (!candidate || candidate.expiresAt <= now) return { status: 'conflict' } as const;
 
-				return this.toCandidateCredentials(candidate);
+				const user = await manager.getRepository(UserEntity).findOneBy({ id: initiatingUserId });
+				const authority = await manager.getRepository(HomeyCloudUserAuthorityEntity).findOneBy({
+					userId: initiatingUserId,
+				});
+				const authorized = user !== null && AUTHORIZED_ROLES.includes(user.role);
+				const authorityCurrent = (authority?.generation ?? 0) === candidate.authorityGeneration;
+				const generationsCurrent =
+					state.activeGrantGeneration === candidate.activeGrantGeneration &&
+					state.configurationGeneration === candidate.configurationGeneration;
+
+				if (!authorized || !authorityCurrent || !generationsCurrent) {
+					await manager.getRepository(HomeyCloudPendingGrantEntity).delete({ transactionId, initiatingUserId });
+
+					return { status: !authorized || !authorityCurrent ? 'authority' : 'conflict' } as const;
+				}
+
+				return { status: 'loaded', candidate: this.toCandidateCredentials(candidate) } as const;
 			}),
 		);
+
+		if (outcome.status !== 'loaded') {
+			if (outcome.status === 'authority') throw new HomeyCloudGrantAuthorityError();
+			throw new HomeyCloudGrantConflictError();
+		}
+
+		return outcome.candidate;
 	}
 
 	async cancelCandidate(transactionId: string, initiatingUserId: string): Promise<boolean> {
@@ -676,12 +721,16 @@ export class HomeyCloudGrantMutationService
 
 	private assertCandidate(input: HomeyCloudCandidateInput): void {
 		this.assertIdentifier(input.transactionId);
-		this.assertIdentifier(input.initiatingUserId);
 		this.assertIdentifier(input.redirectUrl);
-		this.assertGeneration(input.authorityGeneration);
-		this.assertGeneration(input.activeGrantGeneration);
-		this.assertGeneration(input.configurationGeneration);
+		this.assertAuthorizationContext(input);
 		this.assertToken(input.token);
+	}
+
+	private assertAuthorizationContext(context: HomeyCloudAuthorizationContext): void {
+		this.assertIdentifier(context.initiatingUserId);
+		this.assertGeneration(context.authorityGeneration);
+		this.assertGeneration(context.activeGrantGeneration);
+		this.assertGeneration(context.configurationGeneration);
 	}
 
 	private assertToken(token: HomeyCloudTokenMaterial): void {

--- a/docs/homey-cloud-oauth.md
+++ b/docs/homey-cloud-oauth.md
@@ -189,13 +189,13 @@ delegation token, its SDK-provided remote URL must be a credential-free, path-fr
 `*.connect.athom.com` host label; redirects are disabled. Retryable HTTP status is captured before the child SDK can
 normalize its discovery response into a status-free error. The service validates and stages only the normalized token
 fields, then recreates an isolated candidate client from the exact transaction for Homey listing and selection.
-Browser-facing choices contain only a bounded stable ID and sanitized name. Unsupported or duplicate entries fail closed;
-one eligible Homey is auto-selected, after a fresh singleton-inventory check, while multiple choices require an exact
-transaction-bound selection. The selected Homey must authenticate over the cloud strategy before the existing mutation
-gate can atomically activate it. Invalid-token, malformed-response,
-empty-inventory and unsupported-inventory failures clear only that candidate; transient timeout, rate-limit, and
-unavailable failures retain it until its original absolute expiry. HTTP routes and connector activation remain
-intentionally absent until Tasks 7.2d and 7.3.
+Browser-facing choices contain only a bounded stable ID and sanitized name. Unsupported entries are filtered, while
+duplicate eligible entries fail closed; an inventory with no eligible Homeys is terminal. One eligible Homey is
+auto-selected, after a fresh singleton-inventory check, while multiple choices require an exact transaction-bound
+selection. The selected Homey must authenticate over the cloud strategy before the existing mutation gate can atomically
+activate it. Invalid-token, malformed-response, empty-inventory and all-unsupported-inventory failures clear only that
+candidate; transient timeout, rate-limit, and unavailable failures retain it until its original absolute expiry. HTTP
+routes and connector activation remain intentionally absent until Tasks 7.2d and 7.3.
 
 The current official client and HTTP references do not document a standards-style token-revocation endpoint. Task 7.2
 must verify the current live/API behavior before claiming remote revocation. Until then, disconnect means local token

--- a/docs/homey-cloud-oauth.md
+++ b/docs/homey-cloud-oauth.md
@@ -178,8 +178,17 @@ checks so a late provider result cannot revive cleared credentials or overwrite 
 and removal participate in the same user database transaction through the additive user-lifecycle mutation boundary;
 this advances the user's authority generation and clears credentials authorized by that user before the account change
 commits. The provider factory-reset handler clears pending grants, active credentials and user-authority metadata before
-the core device and user reset handlers run, while advancing both persisted generations. Provider exchange, Homey
-selection and HTTP routes remain intentionally absent until Tasks 7.2c and 7.2d.
+the core device and user reset handlers run, while advancing both persisted generations.
+
+Task 7.2c adds the provider boundary behind disabled cloud mode. It revalidates the initiating authority and deployment
+generations before sending the authorization code, exchanges through an automatic-refresh-disabled SDK client with a
+bounded deadline, validates and stages only the normalized token fields, and recreates an isolated candidate client
+from the exact transaction for Homey listing and selection. Browser-facing choices contain only a bounded stable ID and
+sanitized name. Unsupported or duplicate entries fail closed; one eligible Homey is auto-selected, while multiple
+choices require an exact transaction-bound selection. The selected Homey must authenticate over the cloud strategy
+before the existing mutation gate can atomically activate it. Invalid-token, malformed-response, empty-inventory and
+unsupported-inventory failures clear only that candidate; transient timeout/unavailable failures retain it until its
+original absolute expiry. HTTP routes and connector activation remain intentionally absent until Tasks 7.2d and 7.3.
 
 The current official client and HTTP references do not document a standards-style token-revocation endpoint. Task 7.2
 must verify the current live/API behavior before claiming remote revocation. Until then, disconnect means local token

--- a/docs/homey-cloud-oauth.md
+++ b/docs/homey-cloud-oauth.md
@@ -187,8 +187,9 @@ from the exact transaction for Homey listing and selection. Browser-facing choic
 sanitized name. Unsupported or duplicate entries fail closed; one eligible Homey is auto-selected, while multiple
 choices require an exact transaction-bound selection. The selected Homey must authenticate over the cloud strategy
 before the existing mutation gate can atomically activate it. Invalid-token, malformed-response, empty-inventory and
-unsupported-inventory failures clear only that candidate; transient timeout/unavailable failures retain it until its
-original absolute expiry. HTTP routes and connector activation remain intentionally absent until Tasks 7.2d and 7.3.
+unsupported-inventory failures clear only that candidate; transient timeout, rate-limit, and unavailable failures retain
+it until its original absolute expiry. HTTP routes and connector activation remain intentionally absent until Tasks
+7.2d and 7.3.
 
 The current official client and HTTP references do not document a standards-style token-revocation endpoint. Task 7.2
 must verify the current live/API behavior before claiming remote revocation. Until then, disconnect means local token

--- a/docs/homey-cloud-oauth.md
+++ b/docs/homey-cloud-oauth.md
@@ -184,12 +184,12 @@ Task 7.2c adds the provider boundary behind disabled cloud mode. It revalidates 
 generations before sending the authorization code. The factory rejects SDK API-base overrides unless they resolve to the
 exact Athom API origin. Authorization-code exchange uses the pinned Athom token endpoint, while account requests validate
 their final prepared origin before dispatch; all provider operations consume the authorization service's abort signal and
-have a bounded deadline. The service validates and stages only the normalized token fields, then recreates an isolated
-candidate client from the exact transaction for Homey listing and selection. Browser-facing choices contain only a
-bounded stable ID and sanitized name. Unsupported or duplicate entries fail closed; one eligible Homey is auto-selected,
-after a fresh singleton-inventory check, while multiple choices require an exact transaction-bound selection. The
-selected Homey must authenticate over the cloud strategy before the existing mutation gate can atomically activate it.
-Invalid-token, malformed-response,
+have a bounded deadline through complete response-body consumption. The service validates and stages only the normalized
+token fields, then recreates an isolated candidate client from the exact transaction for Homey listing and selection.
+Browser-facing choices contain only a bounded stable ID and sanitized name. Unsupported or duplicate entries fail closed;
+one eligible Homey is auto-selected, after a fresh singleton-inventory check, while multiple choices require an exact
+transaction-bound selection. The selected Homey must authenticate over the cloud strategy before the existing mutation
+gate can atomically activate it. Invalid-token, malformed-response,
 empty-inventory and unsupported-inventory failures clear only that candidate; transient timeout, rate-limit, and
 unavailable failures retain it until its original absolute expiry. HTTP routes and connector activation remain
 intentionally absent until Tasks 7.2d and 7.3.

--- a/docs/homey-cloud-oauth.md
+++ b/docs/homey-cloud-oauth.md
@@ -181,15 +181,17 @@ commits. The provider factory-reset handler clears pending grants, active creden
 the core device and user reset handlers run, while advancing both persisted generations.
 
 Task 7.2c adds the provider boundary behind disabled cloud mode. It revalidates the initiating authority and deployment
-generations before sending the authorization code, exchanges through an automatic-refresh-disabled SDK client with a
-bounded deadline, validates and stages only the normalized token fields, and recreates an isolated candidate client
-from the exact transaction for Homey listing and selection. Browser-facing choices contain only a bounded stable ID and
-sanitized name. Unsupported or duplicate entries fail closed; one eligible Homey is auto-selected, while multiple
-choices require an exact transaction-bound selection. The selected Homey must authenticate over the cloud strategy
-before the existing mutation gate can atomically activate it. Invalid-token, malformed-response, empty-inventory and
-unsupported-inventory failures clear only that candidate; transient timeout, rate-limit, and unavailable failures retain
-it until its original absolute expiry. HTTP routes and connector activation remain intentionally absent until Tasks
-7.2d and 7.3.
+generations before sending the authorization code. The factory rejects SDK API-base overrides unless they resolve to the
+exact Athom API origin. Authorization-code exchange uses the pinned Athom token endpoint, while account requests validate
+their final prepared origin before dispatch; all provider operations consume the authorization service's abort signal and
+have a bounded deadline. The service validates and stages only the normalized token fields, then recreates an isolated
+candidate client from the exact transaction for Homey listing and selection. Browser-facing choices contain only a
+bounded stable ID and sanitized name. Unsupported or duplicate entries fail closed; one eligible Homey is auto-selected,
+while multiple choices require an exact transaction-bound selection. The selected Homey must authenticate over the cloud
+strategy before the existing mutation gate can atomically activate it. Invalid-token, malformed-response,
+empty-inventory and unsupported-inventory failures clear only that candidate; transient timeout, rate-limit, and
+unavailable failures retain it until its original absolute expiry. HTTP routes and connector activation remain
+intentionally absent until Tasks 7.2d and 7.3.
 
 The current official client and HTTP references do not document a standards-style token-revocation endpoint. Task 7.2
 must verify the current live/API behavior before claiming remote revocation. Until then, disconnect means local token

--- a/docs/homey-cloud-oauth.md
+++ b/docs/homey-cloud-oauth.md
@@ -184,8 +184,10 @@ Task 7.2c adds the provider boundary behind disabled cloud mode. It revalidates 
 generations before sending the authorization code. The factory rejects SDK API-base overrides unless they resolve to the
 exact Athom API origin. Authorization-code exchange uses the pinned Athom token endpoint, while account requests validate
 their final prepared origin before dispatch; all provider operations consume the authorization service's abort signal and
-have a bounded deadline through complete response-body consumption. The service validates and stages only the normalized
-token fields, then recreates an isolated candidate client from the exact transaction for Homey listing and selection.
+have a bounded deadline through complete response-body consumption. Before child authentication can mint and send a
+delegation token, its SDK-provided remote URL must be a credential-free, path-free HTTPS endpoint on one exact
+`*.connect.athom.com` host label; redirects are disabled. The service validates and stages only the normalized token
+fields, then recreates an isolated candidate client from the exact transaction for Homey listing and selection.
 Browser-facing choices contain only a bounded stable ID and sanitized name. Unsupported or duplicate entries fail closed;
 one eligible Homey is auto-selected, after a fresh singleton-inventory check, while multiple choices require an exact
 transaction-bound selection. The selected Homey must authenticate over the cloud strategy before the existing mutation

--- a/docs/homey-cloud-oauth.md
+++ b/docs/homey-cloud-oauth.md
@@ -186,7 +186,8 @@ exact Athom API origin. Authorization-code exchange uses the pinned Athom token 
 their final prepared origin before dispatch; all provider operations consume the authorization service's abort signal and
 have a bounded deadline through complete response-body consumption. Before child authentication can mint and send a
 delegation token, its SDK-provided remote URL must be a credential-free, path-free HTTPS endpoint on one exact
-`*.connect.athom.com` host label; redirects are disabled. The service validates and stages only the normalized token
+`*.connect.athom.com` host label; redirects are disabled. Retryable HTTP status is captured before the child SDK can
+normalize its discovery response into a status-free error. The service validates and stages only the normalized token
 fields, then recreates an isolated candidate client from the exact transaction for Homey listing and selection.
 Browser-facing choices contain only a bounded stable ID and sanitized name. Unsupported or duplicate entries fail closed;
 one eligible Homey is auto-selected, after a fresh singleton-inventory check, while multiple choices require an exact

--- a/docs/homey-cloud-oauth.md
+++ b/docs/homey-cloud-oauth.md
@@ -187,8 +187,9 @@ their final prepared origin before dispatch; all provider operations consume the
 have a bounded deadline. The service validates and stages only the normalized token fields, then recreates an isolated
 candidate client from the exact transaction for Homey listing and selection. Browser-facing choices contain only a
 bounded stable ID and sanitized name. Unsupported or duplicate entries fail closed; one eligible Homey is auto-selected,
-while multiple choices require an exact transaction-bound selection. The selected Homey must authenticate over the cloud
-strategy before the existing mutation gate can atomically activate it. Invalid-token, malformed-response,
+after a fresh singleton-inventory check, while multiple choices require an exact transaction-bound selection. The
+selected Homey must authenticate over the cloud strategy before the existing mutation gate can atomically activate it.
+Invalid-token, malformed-response,
 empty-inventory and unsupported-inventory failures clear only that candidate; transient timeout, rate-limit, and
 unavailable failures retain it until its original absolute expiry. HTTP routes and connector activation remain
 intentionally absent until Tasks 7.2d and 7.3.

--- a/docs/homey-cloud-oauth.md
+++ b/docs/homey-cloud-oauth.md
@@ -189,7 +189,7 @@ delegation token, its SDK-provided remote URL must be a credential-free, path-fr
 `*.connect.athom.com` host label; redirects are disabled. Retryable HTTP status is captured before the child SDK can
 normalize its discovery response into a status-free error. The service validates and stages only the normalized token
 fields, then recreates an isolated candidate client from the exact transaction for Homey listing and selection.
-Browser-facing choices contain only a bounded stable ID and sanitized name. Unsupported entries are filtered, while
+Browser-facing choices contain only a bounded, Unicode-control-free stable ID and sanitized name. Unsupported entries are filtered, while
 duplicate eligible entries fail closed; an inventory with no eligible Homeys is terminal. One eligible Homey is
 auto-selected, after a fresh singleton-inventory check, while multiple choices require an exact transaction-bound
 selection. The selected Homey must authenticate over the cloud strategy before the existing mutation gate can atomically

--- a/docs/superpowers/plans/2026-08-12-homey-integration.md
+++ b/docs/superpowers/plans/2026-08-12-homey-integration.md
@@ -851,7 +851,7 @@ Task 7.2 is delivered behind disabled cloud mode in reviewable slices:
 - [x] **7.2b — Grant persistence and mutation gate:** add incremental storage for pending/active grant metadata and
       write-only token material, then serialize activation, cancellation, expiry, refresh, disconnect, configuration,
       and user-authority invalidation.
-- [ ] **7.2c — Provider exchange and Homey selection:** exchange the code with a bounded timeout, stage candidate tokens,
+- [x] **7.2c — Provider exchange and Homey selection:** exchange the code with a bounded timeout, stage candidate tokens,
       sanitize eligible Homey choices, support exact transaction-bound selection, authenticate the selected Homey, and
       activate only through the mutation gate.
 - [ ] **7.2d — HTTP authorization surface:** add privileged start/select/cancel/disconnect/reconnect routes plus the


### PR DESCRIPTION
## Summary

- exchange Homey authorization codes through an automatic-refresh-disabled SDK client with bounded, cancellable provider deadlines
- pin code exchange and account requests to the exact Athom API origin, reject SDK base-URL overrides, and disable redirects for credential-bearing requests
- validate child Homey cloud URLs before delegation and propagate cancellation through response-body consumption plus discovery/login/session requests
- preserve timeout and retryable HTTP/network classification through body parsing and SDK normalization, retaining candidates for transient failures
- stage normalized candidate credentials and expose only bounded, Unicode-control-free Homey choices
- require exact transaction-bound selection for multi-Homey accounts and enforce singleton inventory through the final automatic-authentication snapshot
- authenticate supported API-v1/v2/v3 Homeys and clean up only lifecycle methods exposed by each SDK client
- activate through the race-safe existing grant mutation gate after authentication
- clear terminal candidates while retaining transient timeout, rate-limit, and unavailable candidates until their original expiry
- revalidate authority and deployment generations before provider access and reject stale candidates before additional provider calls
- record Task 7.2c as complete while leaving the HTTP authorization surface and cloud connector to Tasks 7.2d and 7.3

## Verification

- `pnpm exec eslint` on all changed backend TypeScript files
- `pnpm run type-check`
- `pnpm exec jest --runInBand src/plugins/devices-homey` (42 suites, 530 tests)
- `pnpm run generate:openapi`
- `git diff --check`

## Scope

This PR intentionally exposes no OAuth HTTP routes and does not activate cloud mode. Those boundaries remain disabled until Task 7.2d and the cloud connector work.




